### PR TITLE
fix: correct CLI flags and lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Documentation readability analyzer - GitHub Action and CLI tool for measuring co
 - **Flesch Reading Ease** - How easy is your content to read?
 - **Grade Level Scores** - Flesch-Kincaid, Gunning Fog, Coleman-Liau, SMOG, ARI
 - **Word & Sentence Metrics** - Count, averages, complexity indicators
-- **Multiple Output Formats** - Table, Markdown, JSON
+- **Multiple Output Formats** - Table, Markdown, JSON, Summary, Report
 - **Threshold Enforcement** - Fail CI when quality drops
 
 ## Quick Start
@@ -20,7 +20,7 @@ Documentation readability analyzer - GitHub Action and CLI tool for measuring co
     path: docs/
     format: markdown
     check: true
-    threshold-flesch: 30
+    max-grade: 12
 ```
 
 ### CLI
@@ -30,13 +30,16 @@ Documentation readability analyzer - GitHub Action and CLI tool for measuring co
 go install github.com/adaptive-enforcement-lab/readability/cmd/readability@latest
 
 # Analyze a directory
-readability --recursive docs/
+readability docs/
 
 # Check with thresholds
-readability --check --threshold-flesch 30 docs/
+readability --check --max-grade 12 docs/
 
 # Output as JSON
 readability --format json docs/
+
+# Use a config file
+readability --config .readability.yml docs/
 ```
 
 ## Metrics
@@ -52,30 +55,47 @@ readability --format json docs/
 
 ## Configuration
 
-Create `.readability.yml` in your repo:
+Create `.content-analyzer.yml` in your repo:
 
 ```yaml
 thresholds:
-  flesch: 30
-  grade: 12
-  words: 3000
+  max_grade: 12
+  max_ari: 12
+  max_fog: 12
+  min_ease: 30
+  max_lines: 500
+  min_words: 100
 
-ignore:
-  - "docs/api/**"
-  - "CHANGELOG.md"
+overrides:
+  - pattern: "docs/api/**"
+    thresholds:
+      max_grade: 14
+      max_lines: 1000
 ```
 
 ## Action Inputs
 
 | Input | Description | Default |
 |-------|-------------|---------|
-| `path` | Path to analyze | `docs/` |
-| `format` | Output format (table, markdown, json) | `markdown` |
+| `path` | Path to analyze (file or directory) | `docs/` |
+| `format` | Output format (table, markdown, json, summary, report) | `markdown` |
+| `config` | Path to config file | (auto-detect) |
 | `check` | Fail on threshold violations | `false` |
-| `threshold-flesch` | Minimum Flesch score | `30` |
-| `threshold-grade` | Maximum grade level | `12` |
-| `threshold-words` | Maximum words per file | `3000` |
-| `recursive` | Analyze subdirectories | `true` |
+| `max-grade` | Maximum Flesch-Kincaid grade level | (from config) |
+| `max-ari` | Maximum ARI score | (from config) |
+| `max-lines` | Maximum lines per file | (from config) |
+
+## CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--format, -f` | Output format: table, json, markdown, summary, report |
+| `--verbose, -v` | Show all metrics |
+| `--check` | Check against thresholds (exit 1 on failure) |
+| `--config, -c` | Path to config file |
+| `--max-grade` | Maximum Flesch-Kincaid grade level |
+| `--max-ari` | Maximum ARI score |
+| `--max-lines` | Maximum lines per file (0 to disable) |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: 'docs/'
   format:
-    description: 'Output format (table, markdown, json)'
+    description: 'Output format (table, markdown, json, summary, report)'
     required: false
     default: 'markdown'
   config:
@@ -23,22 +23,18 @@ inputs:
     description: 'Enable check mode (fail on threshold violations)'
     required: false
     default: 'false'
-  threshold-flesch:
-    description: 'Minimum Flesch Reading Ease score'
+  max-grade:
+    description: 'Maximum Flesch-Kincaid grade level'
     required: false
-    default: '30'
-  threshold-grade:
-    description: 'Maximum grade level'
+    default: ''
+  max-ari:
+    description: 'Maximum ARI score'
     required: false
-    default: '12'
-  threshold-words:
-    description: 'Maximum words per file'
+    default: ''
+  max-lines:
+    description: 'Maximum lines per file'
     required: false
-    default: '3000'
-  recursive:
-    description: 'Analyze directories recursively'
-    required: false
-    default: 'true'
+    default: ''
 
 outputs:
   report:
@@ -47,10 +43,6 @@ outputs:
     description: 'Whether all thresholds were met (true/false)'
   files-analyzed:
     description: 'Number of files analyzed'
-  average-flesch:
-    description: 'Average Flesch Reading Ease score'
-  average-grade:
-    description: 'Average grade level'
 
 runs:
   using: 'composite'
@@ -79,15 +71,20 @@ runs:
 
         ARGS="$ARGS --format ${{ inputs.format }}"
 
-        if [ "${{ inputs.recursive }}" = "true" ]; then
-          ARGS="$ARGS --recursive"
-        fi
-
         if [ "${{ inputs.check }}" = "true" ]; then
           ARGS="$ARGS --check"
-          ARGS="$ARGS --threshold-flesch ${{ inputs.threshold-flesch }}"
-          ARGS="$ARGS --threshold-grade ${{ inputs.threshold-grade }}"
-          ARGS="$ARGS --threshold-words ${{ inputs.threshold-words }}"
+        fi
+
+        if [ -n "${{ inputs.max-grade }}" ]; then
+          ARGS="$ARGS --max-grade ${{ inputs.max-grade }}"
+        fi
+
+        if [ -n "${{ inputs.max-ari }}" ]; then
+          ARGS="$ARGS --max-ari ${{ inputs.max-ari }}"
+        fi
+
+        if [ -n "${{ inputs.max-lines }}" ]; then
+          ARGS="$ARGS --max-lines ${{ inputs.max-lines }}"
         fi
 
         ${{ github.action_path }}/readability $ARGS ${{ inputs.path }}

--- a/cmd/readability/main.go
+++ b/cmd/readability/main.go
@@ -23,7 +23,7 @@ var (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "content-analyzer [path]",
+		Use:   "readability [path]",
 		Short: "Analyze markdown documentation for readability and structure",
 		Long: `A tool for analyzing documentation quality, readability, and structure.
 
@@ -35,12 +35,12 @@ Configuration:
   CLI flags override config file values.
 
 Examples:
-  content-analyzer docs/quickstart.md
-  content-analyzer docs/
-  content-analyzer docs/ --format json
-  content-analyzer docs/ --format markdown
-  content-analyzer docs/ --check
-  content-analyzer docs/ --config .content-analyzer.yml`,
+  readability docs/quickstart.md
+  readability docs/
+  readability docs/ --format json
+  readability docs/ --format markdown
+  readability docs/ --check
+  readability docs/ --config .content-analyzer.yml`,
 		Args: cobra.ExactArgs(1),
 		RunE: run,
 	}


### PR DESCRIPTION
## Summary
- Fix action.yml to use actual CLI flags (max-grade, max-ari, max-lines)
- Remove non-existent flags (recursive, threshold-flesch/grade/words)
- Fix lint errors in parser.go

## Test plan
- [ ] CI build passes
- [ ] Lint passes
- [ ] Action test succeeds