### PR TITLE
fix: ensure CNAME persists for custom domain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,18 @@ jobs:
         run: |
           mike deploy --push dev
 
+      - name: Ensure CNAME file
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          if [ ! -f CNAME ]; then
+            echo "readability.adaptive-enforcement-lab.com" > CNAME
+            git add CNAME
+            git commit -m "chore: add CNAME for custom domain"
+            git push origin gh-pages
+          fi
+          git checkout main
+
   release-status:
     name: Release Status
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add workflow step to ensure CNAME file exists on gh-pages branch after mike deploys
- This ensures the custom domain (readability.adaptive-enforcement-lab.com) is preserved

## DNS Setup Required
You need to add a CNAME record to your DNS:

```
readability.adaptive-enforcement-lab.com -> adaptive-enforcement-lab.github.io
```

## Test plan
- [ ] CI passes
- [ ] After merge, docs are accessible at custom domain