### PR TITLE
fix: action config auto-detection and outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,11 +65,15 @@ runs:
       run: |
         ARGS=""
 
+        # Auto-detect config file if not specified
         if [ -n "${{ inputs.config }}" ]; then
           ARGS="$ARGS --config ${{ inputs.config }}"
+        elif [ -f ".readability.yml" ]; then
+          ARGS="$ARGS --config .readability.yml"
         fi
 
-        ARGS="$ARGS --format ${{ inputs.format }}"
+        # Always use JSON for capturing outputs, then convert for display
+        ARGS="$ARGS --format json"
 
         if [ "${{ inputs.check }}" = "true" ]; then
           ARGS="$ARGS --check"
@@ -87,4 +91,57 @@ runs:
           ARGS="$ARGS --max-lines ${{ inputs.max-lines }}"
         fi
 
-        ${{ github.action_path }}/readability $ARGS ${{ inputs.path }}
+        # Run analysis and capture output
+        set +e
+        OUTPUT=$(${{ github.action_path }}/readability $ARGS ${{ inputs.path }} 2>&1)
+        EXIT_CODE=$?
+        set -e
+
+        # Parse JSON output for metrics
+        FILES_ANALYZED=$(echo "$OUTPUT" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null || echo "0")
+        FAILED_COUNT=$(echo "$OUTPUT" | jq -r '[.[] | select(.status == "fail")] | length' 2>/dev/null || echo "0")
+
+        if [ "$FAILED_COUNT" -eq 0 ]; then
+          PASSED="true"
+        else
+          PASSED="false"
+        fi
+
+        # Set outputs
+        echo "files-analyzed=$FILES_ANALYZED" >> "$GITHUB_OUTPUT"
+        echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+
+        # Store full report
+        {
+          echo "report<<EOF"
+          echo "$OUTPUT"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        # Generate formatted output for display
+        FORMAT="${{ inputs.format }}"
+        case "$FORMAT" in
+          json)
+            echo "$OUTPUT"
+            ;;
+          markdown|report)
+            echo "$OUTPUT" | jq -r '
+              "| File | Grade | ARI | Fog | Ease | Status |",
+              "|------|-------|-----|-----|------|--------|",
+              (.[] | "| \(.file) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
+            ' 2>/dev/null || echo "$OUTPUT"
+            ;;
+          summary)
+            echo "$OUTPUT" | jq -r '
+              "Files analyzed: \(length)",
+              "Passed: \([.[] | select(.status == "pass")] | length)",
+              "Failed: \([.[] | select(.status == "fail")] | length)"
+            ' 2>/dev/null || echo "$OUTPUT"
+            ;;
+          *)
+            echo "$OUTPUT" | jq -r '.[] | "\(.file): Grade=\(.readability.flesch_kincaid_grade | . * 10 | round / 10), Status=\(.status)"' 2>/dev/null || echo "$OUTPUT"
+            ;;
+        esac
+
+        # Exit with original code to respect --check
+        exit $EXIT_CODE

--- a/cmd/readability/main.go
+++ b/cmd/readability/main.go
@@ -31,7 +31,7 @@ Computes readability metrics (Flesch-Kincaid, ARI, Coleman-Liau, etc.),
 structural analysis (headings, line counts), and content composition.
 
 Configuration:
-  Reads .content-analyzer.yml from the target directory or git root.
+  Reads .readability.yml from the target directory or git root.
   CLI flags override config file values.
 
 Examples:
@@ -40,7 +40,7 @@ Examples:
   readability docs/ --format json
   readability docs/ --format markdown
   readability docs/ --check
-  readability docs/ --config .content-analyzer.yml`,
+  readability docs/ --config .readability.yml`,
 		Args: cobra.ExactArgs(1),
 		RunE: run,
 	}
@@ -48,7 +48,7 @@ Examples:
 	rootCmd.Flags().StringVarP(&formatFlag, "format", "f", "table", "Output format: table, json, markdown, summary, report")
 	rootCmd.Flags().BoolVarP(&verboseFlag, "verbose", "v", false, "Show all metrics")
 	rootCmd.Flags().BoolVar(&checkFlag, "check", false, "Check against thresholds (exit 1 on failure)")
-	rootCmd.Flags().StringVarP(&configFlag, "config", "c", "", "Path to config file (default: auto-detect .content-analyzer.yml)")
+	rootCmd.Flags().StringVarP(&configFlag, "config", "c", "", "Path to config file (default: auto-detect .readability.yml)")
 	rootCmd.Flags().Float64Var(&maxGradeFlag, "max-grade", 0, "Maximum Flesch-Kincaid grade level (overrides config)")
 	rootCmd.Flags().Float64Var(&maxARIFlag, "max-ari", 0, "Maximum ARI score (overrides config)")
 	rootCmd.Flags().IntVar(&maxLinesFlag, "max-lines", 0, "Maximum lines per file (overrides config, 0 to disable)")

--- a/docs/cli/config-file.md
+++ b/docs/cli/config-file.md
@@ -1,57 +1,165 @@
 # Configuration File
 
-Readability automatically looks for `.content-analyzer.yml` in the target directory or git root.
+Readability automatically looks for `.readability.yml` in the target directory or git root.
 
-## File Format
+## File Location
+
+The tool searches for the config file in this order:
+
+1. The directory being analyzed
+2. Parent directories up to the git root
+3. If not found, uses built-in defaults
+
+You can also specify a config file explicitly:
+
+```bash
+readability --config /path/to/.readability.yml docs/
+```
+
+## Complete Example
 
 ```yaml
+# .readability.yml
 thresholds:
-  max_grade: 12      # Maximum Flesch-Kincaid grade
-  max_ari: 12        # Maximum ARI score
-  max_fog: 12        # Maximum Gunning Fog index
-  min_ease: 30       # Minimum Flesch Reading Ease
+  max_grade: 12      # Maximum Flesch-Kincaid grade level
+  max_ari: 12        # Maximum Automated Readability Index
+  max_fog: 14        # Maximum Gunning Fog index
+  min_ease: 30       # Minimum Flesch Reading Ease (0-100)
   max_lines: 500     # Maximum lines per file
-  min_words: 100     # Minimum words (skip readability check if below)
+  min_words: 100     # Skip readability check if below this word count
 
 overrides:
-  - pattern: "docs/api/**"
+  # API reference docs can be more technical
+  - path: docs/api/
     thresholds:
-      max_grade: 14    # Allow higher grade for API docs
+      max_grade: 16
+      max_ari: 16
       max_lines: 1000
-  - pattern: "docs/tutorials/**"
+
+  # Tutorials should be beginner-friendly
+  - path: docs/tutorials/
     thresholds:
-      max_grade: 8     # Stricter for tutorials
+      max_grade: 8
+      max_ari: 8
+      min_ease: 60
+
+  # Reference docs with lots of lists/tables break formulas
+  - path: docs/reference/
+    thresholds:
+      max_grade: 50
+      max_ari: 50
+      min_ease: -100  # Negative value disables this check
 ```
 
 ## Threshold Fields
 
-| Field | Description |
-|-------|-------------|
-| `max_grade` | Maximum Flesch-Kincaid grade level |
-| `max_ari` | Maximum ARI score |
-| `max_fog` | Maximum Gunning Fog index |
-| `min_ease` | Minimum Flesch Reading Ease score |
-| `max_lines` | Maximum lines per file |
-| `min_words` | Skip readability checks if word count is below this |
+| Field | Description | Default |
+|-------|-------------|---------|
+| `max_grade` | Maximum Flesch-Kincaid grade level | `16.0` |
+| `max_ari` | Maximum Automated Readability Index | `16.0` |
+| `max_fog` | Maximum Gunning Fog index | `18.0` |
+| `min_ease` | Minimum Flesch Reading Ease score | `25.0` |
+| `max_lines` | Maximum lines per file | `375` |
+| `min_words` | Skip readability checks if word count is below this | `100` |
 
-## Overrides
+### Understanding the Defaults
 
-Use `overrides` to set different thresholds for specific paths:
+The defaults target **college senior level** reading comprehension:
+
+| Grade Level | Audience |
+|-------------|----------|
+| 6-8 | Middle school |
+| 8-10 | MIL-STD-38784 (military technical manuals) |
+| 10-12 | High school |
+| 12-14 | College freshman/sophomore |
+| 14-16 | College junior/senior |
+| 16+ | Graduate level |
+
+### Disabling Checks
+
+Use extreme values to effectively disable specific checks:
+
+```yaml
+thresholds:
+  max_grade: 50      # Effectively no grade limit
+  min_ease: -100     # Negative values disable ease check
+  max_lines: 0       # Zero disables line limit (via CLI only)
+```
+
+## Path Overrides
+
+Use `overrides` to apply different thresholds to specific directories or files.
+
+### Matching Rules
+
+- Paths use **prefix matching**
+- First matching override wins (order matters)
+- Unmatched files use the base `thresholds`
+- Paths are normalized (leading `./` and `../` stripped)
+
+### Override Examples
 
 ```yaml
 overrides:
-  - pattern: "docs/api/**"
+  # Match all files under docs/api/
+  - path: docs/api/
+    thresholds:
+      max_grade: 16
+
+  # Match a specific file
+  - path: docs/changelog.md
+    thresholds:
+      max_lines: 2000
+
+  # More specific paths should come first
+  - path: docs/guides/advanced/
     thresholds:
       max_grade: 14
+  - path: docs/guides/
+    thresholds:
+      max_grade: 10
 ```
 
-Patterns use glob syntax.
+### Partial Overrides
+
+Override only the thresholds you need; others inherit from the base:
+
+```yaml
+thresholds:
+  max_grade: 12
+  max_ari: 12
+  max_lines: 500
+
+overrides:
+  - path: docs/api/
+    thresholds:
+      max_grade: 16  # Only override grade; ari and lines inherit
+```
 
 ## CLI Overrides
 
-CLI flags override config file values:
+Command-line flags take precedence over config file values:
 
 ```bash
 # Config says max_grade: 12, but use 10 for this run
 readability --max-grade 10 docs/
+
+# Disable line limit for a single run
+readability --max-lines 0 docs/
+
+# Use a different config file
+readability --config custom-config.yml docs/
 ```
+
+## GitHub Action Usage
+
+The GitHub Action automatically detects `.readability.yml`:
+
+```yaml
+- uses: adaptive-enforcement-lab/readability@v1
+  with:
+    path: docs/
+    check: true  # Fail if thresholds exceeded
+```
+
+See [GitHub Action Configuration](../github-action/configuration.md) for more options.

--- a/docs/github-action/configuration.md
+++ b/docs/github-action/configuration.md
@@ -6,7 +6,7 @@
 |-------|-------------|---------|
 | `path` | Path to analyze (file or directory) | `docs/` |
 | `format` | Output format (table, markdown, json, summary, report) | `markdown` |
-| `config` | Path to config file | (auto-detect) |
+| `config` | Path to config file | (auto-detect `.readability.yml`) |
 | `check` | Fail on threshold violations | `false` |
 | `max-grade` | Maximum Flesch-Kincaid grade level | (from config) |
 | `max-ari` | Maximum ARI score | (from config) |
@@ -16,9 +16,42 @@
 
 | Output | Description |
 |--------|-------------|
-| `report` | Analysis report in specified format |
-| `passed` | Whether all thresholds were met (true/false) |
+| `report` | Analysis report in JSON format |
+| `passed` | Whether all thresholds were met (`true`/`false`) |
 | `files-analyzed` | Number of files analyzed |
+
+## Configuration File Auto-Detection
+
+The action automatically detects `.readability.yml` in your repository root. You don't need to specify the `config` input unless using a different filename or location.
+
+```yaml
+# .readability.yml is auto-detected
+- uses: adaptive-enforcement-lab/readability@v1
+  with:
+    path: docs/
+    check: true
+```
+
+## Using Outputs
+
+Access the action outputs in subsequent steps:
+
+```yaml
+- uses: adaptive-enforcement-lab/readability@v1
+  id: readability
+  with:
+    path: docs/
+    check: false  # Don't fail, just report
+
+- name: Check results
+  run: |
+    echo "Files analyzed: ${{ steps.readability.outputs.files-analyzed }}"
+    echo "All passed: ${{ steps.readability.outputs.passed }}"
+
+- name: Fail if readability issues
+  if: steps.readability.outputs.passed == 'false'
+  run: exit 1
+```
 
 ## Example with All Options
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,12 +68,15 @@ func LoadOrDefault(path string) *Config {
 	return cfg
 }
 
-// FindConfigFile searches for .content-analyzer.yml in the given directory
+// ConfigFileName is the default configuration file name.
+const ConfigFileName = ".readability.yml"
+
+// FindConfigFile searches for .readability.yml in the given directory
 // and parent directories up to the git root.
 func FindConfigFile(startDir string) string {
 	dir := startDir
 	for {
-		configPath := filepath.Join(dir, ".content-analyzer.yml")
+		configPath := filepath.Join(dir, ConfigFileName)
 		if _, err := os.Stat(configPath); err == nil {
 			return configPath
 		}
@@ -81,11 +84,7 @@ func FindConfigFile(startDir string) string {
 		// Check for git root (stop searching)
 		gitDir := filepath.Join(dir, ".git")
 		if _, err := os.Stat(gitDir); err == nil {
-			// We're at git root, check one more time then stop
-			configPath := filepath.Join(dir, ".content-analyzer.yml")
-			if _, err := os.Stat(configPath); err == nil {
-				return configPath
-			}
+			// We're at git root, already checked above
 			return ""
 		}
 

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -7,14 +7,11 @@ import (
 	"github.com/adaptive-enforcement-lab/readability/pkg/analyzer"
 )
 
-// JSON writes results as JSON.
+// JSON writes results as JSON array.
 func JSON(w io.Writer, results []*analyzer.Result) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 
-	if len(results) == 1 {
-		return encoder.Encode(results[0])
-	}
-
+	// Always return an array for consistent parsing
 	return encoder.Encode(results)
 }


### PR DESCRIPTION
## Summary

- Add auto-detection of `.readability.yml` config file in GitHub Action
- Implement action outputs (`report`, `passed`, `files-analyzed`)
- Rename config file from `.content-analyzer.yml` to `.readability.yml`
- Fix JSON output to always return array for consistent parsing
- Expand configuration file documentation

## Changes

### Action Improvements
- Auto-detects `.readability.yml` without requiring explicit `config` input
- Properly sets outputs for use in subsequent workflow steps
- Formats output based on `format` input while using JSON internally

### Config File Rename
- Primary config file is now `.readability.yml`
- Updated CLI help text and documentation

### Documentation
- Comprehensive config file reference with all options and defaults
- Grade level reference table
- Path override examples and matching rules
- GitHub Action output usage examples

## Test Plan

- [ ] Verify CLI auto-detects `.readability.yml`
- [ ] Verify action outputs are accessible in workflows
- [ ] Verify JSON output is always an array