### PR TITLE
feat: add --version flag

### DIFF
--- a/cmd/readability/main.go
+++ b/cmd/readability/main.go
@@ -11,6 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is set via ldflags at build time
+var version = "dev"
+
 var (
 	formatFlag   string
 	verboseFlag  bool
@@ -23,9 +26,10 @@ var (
 
 func main() {
 	rootCmd := &cobra.Command{
-		Use:   "readability [path]",
-		Short: "Analyze markdown documentation for readability and structure",
-		Long: `A tool for analyzing documentation quality, readability, and structure.
+		Use:     "readability [path]",
+		Short:   "Analyze markdown documentation for readability and structure",
+		Version: version,
+		Long:    `A tool for analyzing documentation quality, readability, and structure.
 
 Computes readability metrics (Flesch-Kincaid, ARI, Coleman-Liau, etc.),
 structural analysis (headings, line counts), and content composition.


### PR DESCRIPTION
## Summary

Add `--version` flag to CLI, with version injected via ldflags at build time.

## Changes

- Add `version` variable defaulting to `dev` for local builds
- Set cobra `Version` field to enable `--version` flag
- Release workflow already injects version via `-ldflags="-X main.version=${VERSION}"`

## Usage

```bash
$ readability --version
readability version 0.3.0
```

## Test Plan

- [x] Local build shows `readability version dev`
- [x] Build with ldflags shows injected version