### PR TITLE
chore: rename CI to Build, run on PRs only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
-name: CI
+name: Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Rename workflow from CI to Build
- Only trigger on pull requests (not push to main)
- Release Pipeline handles main branch builds

## Rationale

Eliminates duplicate builds on main - Release Pipeline already builds and tests on push to main.