### PR TITLE
chore: remove v prefix from release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "include-v-in-tag": true,
+  "include-v-in-tag": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Change release tags from `v0.3.0` to `0.3.0`.

Sets `include-v-in-tag: false` in release-please config.