### PR TITLE
fix: add value mappings for composite action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,11 +38,14 @@ inputs:
 
 outputs:
   report:
-    description: 'Analysis report in specified format'
+    description: 'Analysis report in JSON format'
+    value: ${{ steps.analyze.outputs.report }}
   passed:
     description: 'Whether all thresholds were met (true/false)'
+    value: ${{ steps.analyze.outputs.passed }}
   files-analyzed:
     description: 'Number of files analyzed'
+    value: ${{ steps.analyze.outputs.files-analyzed }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## Summary

Fixes broken action outputs (`report`, `passed`, `files-analyzed`) that were always empty.

## Problem

Composite actions require explicit `value` fields to map step outputs to action-level outputs. The outputs were being set correctly in the `analyze` step using `GITHUB_OUTPUT`, but the action-level outputs didn't reference them.

**Before (broken):**
```yaml
outputs:
  report:
    description: 'Analysis report in specified format'
```

**After (fixed):**
```yaml
outputs:
  report:
    description: 'Analysis report in JSON format'
    value: ${{ steps.analyze.outputs.report }}
```

## Impact

Consumers can now use the outputs in subsequent workflow steps:
```yaml
- name: Analyze documentation
  id: readability
  uses: adaptive-enforcement-lab/readability@main
  with:
    path: docs/

- name: Show results
  run: |
    echo "Passed: ${{ steps.readability.outputs.passed }}"
    echo "Files: ${{ steps.readability.outputs.files-analyzed }}"
```

## Test plan

- [ ] CI passes
- [ ] Test in adaptive-enforcement-lab-com after merge
