### PR TITLE
feat: add automatic job summary generation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,14 @@ inputs:
     description: 'Maximum lines per file'
     required: false
     default: ''
+  summary:
+    description: 'Write formatted report to job summary (default: true)'
+    required: false
+    default: 'true'
+  summary-title:
+    description: 'Title for the job summary section'
+    required: false
+    default: 'Documentation Readability Report'
 
 outputs:
   report:
@@ -121,18 +129,32 @@ runs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
-        # Generate formatted output for display
+        # Generate formatted markdown table
+        MARKDOWN_TABLE=$(echo "$OUTPUT" | jq -r '
+          "| File | Grade | ARI | Fog | Ease | Status |",
+          "|------|-------|-----|-----|------|--------|",
+          (.[] | "| \(.file) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
+        ' 2>/dev/null || echo "$OUTPUT")
+
+        # Write to job summary if enabled
+        if [ "${{ inputs.summary }}" = "true" ] && [ -n "$GITHUB_STEP_SUMMARY" ]; then
+          {
+            echo "## ${{ inputs.summary-title }}"
+            echo ""
+            echo "$MARKDOWN_TABLE"
+            echo ""
+            echo "_Files analyzed: ${FILES_ANALYZED} | Passed: $((FILES_ANALYZED - FAILED_COUNT)) | Failed: ${FAILED_COUNT}_"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+        # Generate formatted output for display (stdout)
         FORMAT="${{ inputs.format }}"
         case "$FORMAT" in
           json)
             echo "$OUTPUT"
             ;;
           markdown|report)
-            echo "$OUTPUT" | jq -r '
-              "| File | Grade | ARI | Fog | Ease | Status |",
-              "|------|-------|-----|-----|------|--------|",
-              (.[] | "| \(.file) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
-            ' 2>/dev/null || echo "$OUTPUT"
+            echo "$MARKDOWN_TABLE"
             ;;
           summary)
             echo "$OUTPUT" | jq -r '


### PR DESCRIPTION
## Summary

Adds automatic job summary generation to eliminate boilerplate in consumer workflows.

Closes #22

## Before

Users had to manually format and write the summary:

```yaml
- name: Analyze documentation
  id: readability
  uses: adaptive-enforcement-lab/readability@0.3.2
  with:
    path: docs/
    check: true

- name: Add report to summary
  run: echo "${{ steps.readability.outputs.report }}" | jq -r '
    "## Documentation Readability Report",
    "",
    "| File | Grade | ARI | Fog | Ease | Status |",
    "|------|-------|-----|-----|------|--------|",
    (.[] | "| \(.file) | ...")
  ' >> "$GITHUB_STEP_SUMMARY"
```

## After

Zero-config - summary is generated automatically:

```yaml
- name: Analyze documentation
  uses: adaptive-enforcement-lab/readability@0.4.0
  with:
    path: docs/
    check: true
```

## New Inputs

| Input | Type | Default | Description |
|-------|------|---------|-------------|
| `summary` | boolean | `true` | Write formatted report to job summary |
| `summary-title` | string | `Documentation Readability Report` | Title for the summary section |

## Generated Summary

The action writes a formatted markdown report to `$GITHUB_STEP_SUMMARY`:

> ## Documentation Readability Report
>
> | File | Grade | ARI | Fog | Ease | Status |
> |------|-------|-----|-----|------|--------|
> | docs/index.md | 6.7 | 5.7 | 7.9 | 58.4 | pass |
> | docs/about.md | 8.2 | 9.1 | 10.2 | 45.3 | pass |
>
> _Files analyzed: 2 | Passed: 2 | Failed: 0_

## Test plan

- [ ] CI passes
- [ ] Test in adaptive-enforcement-lab-com after merge
