### PR TITLE
feat: enhance summary table with lines, reading time, and metric links

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,11 +129,12 @@ runs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
-        # Generate formatted markdown table
-        MARKDOWN_TABLE=$(echo "$OUTPUT" | jq -r '
-          "| File | Grade | ARI | Fog | Ease | Status |",
-          "|------|-------|-----|-----|------|--------|",
-          (.[] | "| \(.file) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
+        # Generate formatted markdown table with metric links to docs
+        DOCS_BASE="https://readability.adaptive-enforcement-lab.com/latest/metrics"
+        MARKDOWN_TABLE=$(echo "$OUTPUT" | jq -r --arg docs "$DOCS_BASE" '
+          "| File | Lines | Read | [Grade](\($docs)/grade-level/#flesch-kincaid-grade-level) | [ARI](\($docs)/grade-level/#ari-automated-readability-index) | [Fog](\($docs)/grade-level/#gunning-fog-index) | [Ease](\($docs)/flesch-reading-ease/) | Status |",
+          "|------|------:|-----:|------:|----:|----:|-----:|--------|",
+          (.[] | "| \(.file) | \(.structural.lines) | \(if .structural.words < 200 then "<1m" else "\(.structural.words / 200 | floor)m" end) | \(.readability.flesch_kincaid_grade | . * 10 | round / 10) | \(.readability.ari | . * 10 | round / 10) | \(.readability.gunning_fog | . * 10 | round / 10) | \(.readability.flesch_reading_ease | . * 10 | round / 10) | \(.status) |")
         ' 2>/dev/null || echo "$OUTPUT")
 
         # Write to job summary if enabled


### PR DESCRIPTION
## Summary

Enhances the job summary table with additional columns and documentation links.

## Changes

### New Columns

| Column | Description |
|--------|-------------|
| **Lines** | Number of lines in the file |
| **Read** | Estimated reading time (e.g., `<1m`, `2m`, `5m`) |

### Documentation Links

Metric column headers now link to their reference documentation:

- **Grade** → [Flesch-Kincaid Grade Level](https://readability.adaptive-enforcement-lab.com/latest/metrics/grade-level/#flesch-kincaid-grade-level)
- **ARI** → [Automated Readability Index](https://readability.adaptive-enforcement-lab.com/latest/metrics/grade-level/#ari-automated-readability-index)
- **Fog** → [Gunning Fog Index](https://readability.adaptive-enforcement-lab.com/latest/metrics/grade-level/#gunning-fog-index)
- **Ease** → [Flesch Reading Ease](https://readability.adaptive-enforcement-lab.com/latest/metrics/flesch-reading-ease/)

## Example Output

| File | Lines | Read | [Grade] | [ARI] | [Fog] | [Ease] | Status |
|------|------:|-----:|------:|----:|----:|-----:|--------|
| docs/index.md | 61 | <1m | 22.7 | 25.9 | 21.4 | -1.0 | pass |
| docs/getting-started/quick-start.md | 69 | <1m | 19.7 | 22.7 | 18.4 | 21.3 | pass |

## Test Plan

- [ ] CI passes
- [ ] Test in adaptive-enforcement-lab-com after merge