### PR TITLE
docs: document job summary feature and table columns

### DIFF
--- a/docs/github-action/configuration.md
+++ b/docs/github-action/configuration.md
@@ -11,6 +11,8 @@
 | `max-grade` | Maximum Flesch-Kincaid grade level | (from config) |
 | `max-ari` | Maximum ARI score | (from config) |
 | `max-lines` | Maximum lines per file | (from config) |
+| `summary` | Write formatted report to job summary | `true` |
+| `summary-title` | Title for the job summary section | `Documentation Readability Report` |
 
 ## Outputs
 
@@ -65,4 +67,45 @@ Access the action outputs in subsequent steps:
     max-grade: 12
     max-ari: 14
     max-lines: 500
+    summary: true
+    summary-title: Documentation Readability Report
+```
+
+## Job Summary
+
+The action automatically writes a formatted report to the GitHub Actions job summary. This is enabled by default (`summary: true`).
+
+### Summary Table Columns
+
+| Column | Description |
+|--------|-------------|
+| **File** | Path to the analyzed file |
+| **Lines** | Number of lines in the file |
+| **Read** | Estimated reading time (e.g., `<1m`, `2m`, `5m`) |
+| **Grade** | [Flesch-Kincaid Grade Level](../metrics/grade-level.md#flesch-kincaid-grade-level) |
+| **ARI** | [Automated Readability Index](../metrics/grade-level.md#ari-automated-readability-index) |
+| **Fog** | [Gunning Fog Index](../metrics/grade-level.md#gunning-fog-index) |
+| **Ease** | [Flesch Reading Ease](../metrics/flesch-reading-ease.md) score |
+| **Status** | `pass` or `fail` based on configured thresholds |
+
+### Disabling the Summary
+
+To disable the job summary:
+
+```yaml
+- uses: adaptive-enforcement-lab/readability@v1
+  with:
+    path: docs/
+    summary: false
+```
+
+### Custom Title
+
+Change the summary section title:
+
+```yaml
+- uses: adaptive-enforcement-lab/readability@v1
+  with:
+    path: docs/
+    summary-title: "Docs Quality Check"
 ```

--- a/docs/github-action/index.md
+++ b/docs/github-action/index.md
@@ -30,6 +30,7 @@ jobs:
 - Multiple output formats
 - Threshold enforcement
 - Configuration file support
+- Automatic job summary with clickable metric links
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Documents the job summary feature added in v0.4.0 and the enhanced table columns added in v0.5.0.

## Changes

### Configuration Docs
- Added `summary` and `summary-title` inputs to the inputs table
- Added new "Job Summary" section with:
  - Table column descriptions
  - Links to metric reference pages
  - Examples for disabling summary
  - Example for custom title

### GitHub Action Index
- Added job summary feature to features list

## Table Columns Documented

| Column | Description |
|--------|-------------|
| File | Path to the analyzed file |
| Lines | Number of lines in the file |
| Read | Estimated reading time |
| Grade | Flesch-Kincaid Grade Level (linked) |
| ARI | Automated Readability Index (linked) |
| Fog | Gunning Fog Index (linked) |
| Ease | Flesch Reading Ease (linked) |
| Status | pass/fail based on thresholds |