### PR TITLE
docs: update pre-commit hook version reference to 0.6.0

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/adaptive-enforcement-lab/readability
-    rev: 0.5.0  # Use latest release
+    rev: 0.6.0  # Use latest release
     hooks:
       - id: readability
         # Optionally check only docs/ directory:


### PR DESCRIPTION
## Summary
- Updates the installation documentation to reference the latest release version 0.6.0

This ensures users following the documentation get the version with native pre-commit hook support.