### PR TITLE
docs: add GitHub icon to header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ theme:
   name: material
   icon:
     logo: material/book-open-page-variant
+    repo: fontawesome/brands/github
   features:
     - content.code.annotate
     - content.code.copy


### PR DESCRIPTION
## Summary

Adds GitHub icon to the documentation header that links to the repository.

## Change

Added `repo: fontawesome/brands/github` to the theme icon configuration. Combined with the existing `repo_url` and `repo_name` settings, this displays a clickable GitHub icon in the header.