### PR TITLE
fix: logo links to docs site instead of main website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@ copyright: |
   &copy; 2025 <a href="https://adaptive-enforcement-lab.com" target="_blank" rel="noopener">Adaptive Enforcement Lab</a>
 extra:
   generator: false
-  homepage: https://adaptive-enforcement-lab.com
   version:
     provider: mike
     default: latest


### PR DESCRIPTION
## Summary

- Removes `extra.homepage` override from mkdocs.yml
- Logo now links to `site_url` (readability.adaptive-enforcement-lab.com) instead of the main company website

## Test plan

- [ ] After deploy, verify clicking the logo in the header returns to the docs home page