### PR TITLE
fix: add admonitions to nav and fix anchor links

### DIFF
--- a/docs/github-action/configuration.md
+++ b/docs/github-action/configuration.md
@@ -82,9 +82,9 @@ The action automatically writes a formatted report to the GitHub Actions job sum
 | **File** | Path to the analyzed file |
 | **Lines** | Number of lines in the file |
 | **Read** | Estimated reading time (e.g., `<1m`, `2m`, `5m`) |
-| **Grade** | [Flesch-Kincaid Grade Level](../metrics/grade-level.md#flesch-kincaid-grade-level) |
-| **ARI** | [Automated Readability Index](../metrics/grade-level.md#ari-automated-readability-index) |
-| **Fog** | [Gunning Fog Index](../metrics/grade-level.md#gunning-fog-index) |
+| **Grade** | [Flesch-Kincaid Grade Level](../metrics/grade-level.md#flesch_kincaid_grade_level) |
+| **ARI** | [Automated Readability Index](../metrics/grade-level.md#ari_automated_readability_index) |
+| **Fog** | [Gunning Fog Index](../metrics/grade-level.md#gunning_fog_index) |
 | **Ease** | [Flesch Reading Ease](../metrics/flesch-reading-ease.md) score |
 | **Status** | `pass` or `fail` based on configured thresholds |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,4 +115,5 @@ nav:
       - metrics/index.md
       - Flesch Reading Ease: metrics/flesch-reading-ease.md
       - Grade Level Scores: metrics/grade-level.md
+      - Admonitions: metrics/admonitions.md
       - Thresholds: metrics/thresholds.md


### PR DESCRIPTION
## Summary

- Adds `metrics/admonitions.md` to the navigation (was missing from nav config)
- Fixes anchor links in `github-action/configuration.md` to use underscores (matches `toc.separator: "_"` config)

Fixes the mkdocs build warnings:
```
INFO - The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - metrics/admonitions.md
INFO - Doc file 'github-action/configuration.md' contains a link '../metrics/grade-level.md#flesch-kincaid-grade-level', but the doc 'metrics/grade-level.md' does not contain an anchor '#flesch-kincaid-grade-level'.
```

## Test plan

- [ ] `mike deploy` runs without warnings about missing nav or broken anchors