### PR TITLE
fix: configure Codecov with OIDC authentication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -23,6 +26,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          use_oidc: true
           files: ./coverage.out
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Summary

Configure Codecov to use OIDC authentication instead of static token. This works with the Codecov GitHub App that's installed on the repository.

## Changes

- Add `use_oidc: true` to codecov-action
- Add `id-token: write` permission for OIDC token generation

## Why

Previous codecov uploads failed with:
```
"Token required - not valid tokenless upload"
```

OIDC authentication allows Codecov to verify the upload request using GitHub's OIDC tokens, which are automatically available when the GitHub App is installed.

## Test plan

- [ ] Codecov upload succeeds with OIDC
- [ ] Coverage badge updates on codecov.io