### PR TITLE
fix: remove duplicate push trigger from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   workflow_call:
     outputs:
       coverage:


### PR DESCRIPTION
## Summary
- Removes duplicate CI runs when pushing to main branch

## Problem
Both `ci.yml` and `release.yml` were triggering on `push: branches: [main]`, causing CI to run twice on every push to main.

## Solution
`ci.yml` now only triggers on:
- `pull_request` - direct CI runs for PRs
- `workflow_call` - called as reusable workflow by release.yml

## Result
On main branch push:
1. `release.yml` triggers
2. `release.yml` calls `ci.yml` via `workflow_call`
3. CI runs once, then release proceeds if CI passes

## Test plan
- [ ] Verify CI runs once on PR merge to main
- [ ] Verify release workflow still calls CI successfully