### PR TITLE
fix: update CI badge to point to ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Readability
 
-[![Build](https://github.com/adaptive-enforcement-lab/readability/actions/workflows/build.yml/badge.svg)](https://github.com/adaptive-enforcement-lab/readability/actions/workflows/build.yml)
+[![CI](https://github.com/adaptive-enforcement-lab/readability/actions/workflows/ci.yml/badge.svg)](https://github.com/adaptive-enforcement-lab/readability/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/adaptive-enforcement-lab/readability/graph/badge.svg)](https://codecov.io/gh/adaptive-enforcement-lab/readability)
 [![Go Report Card](https://goreportcard.com/badge/github.com/adaptive-enforcement-lab/readability)](https://goreportcard.com/report/github.com/adaptive-enforcement-lab/readability)
 


### PR DESCRIPTION
## Summary
- Fixes broken build badge in README

## Problem
The badge was pointing to `build.yml` which was renamed to `ci.yml` during the workflow refactor.

## Fix
Updated badge URL from `workflows/build.yml` to `workflows/ci.yml`