### PR TITLE
fix: improve Go Report Card compliance and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,39 @@
 repos:
   - repo: local
     hooks:
-      - id: readability
-        name: Check documentation readability
-        entry: go run ./cmd/readability --check --format diagnostic docs/
+      - id: gofmt
+        name: Format Go code (gofmt -s)
+        entry: bash -c 'gofmt -s -l -d "$@" | head -20; test -z "$(gofmt -s -l "$@")"' --
         language: system
-        files: '^docs/.*\.md$'
+        files: '\.go$'
+        pass_filenames: true
+
+      - id: go-vet
+        name: Run go vet
+        entry: go vet ./...
+        language: system
+        files: '\.go$'
         pass_filenames: false
+
+      - id: golangci-lint
+        name: Run golangci-lint
+        entry: golangci-lint run --fix
+        language: system
+        files: '\.go$'
+        pass_filenames: false
+
+      - id: gocyclo
+        name: Check cyclomatic complexity (warning)
+        entry: >
+          bash -c '
+          command -v gocyclo >/dev/null || go install github.com/fzipp/gocyclo/cmd/gocyclo@latest;
+          $(go env GOPATH)/bin/gocyclo -over 15 . ||
+          echo "Warning: High complexity functions found (refactoring recommended)"
+          '
+        language: system
+        files: '\.go$'
+        pass_filenames: false
+        verbose: true
 
       - id: go-test
         name: Run Go tests
@@ -30,3 +57,10 @@ repos:
         files: '\.go$'
         pass_filenames: false
         stages: [pre-push]
+
+      - id: readability
+        name: Check documentation readability
+        entry: go run ./cmd/readability --check --format diagnostic docs/
+        language: system
+        files: '^docs/.*\.md$'
+        pass_filenames: false

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -269,13 +269,13 @@ func TestAnalyzeDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	files := map[string]string{
-		"doc1.md":           "# Doc 1\n\nContent one.",
-		"doc2.md":           "# Doc 2\n\nContent two.",
-		"subdir/doc3.md":    "# Doc 3\n\nContent three.",
-		"README.md":         "# README\n\nThis is readme.",
-		"CHANGELOG.md":      "# Changelog\n\nChanges here.", // Should be skipped
-		"CONTRIBUTING.md":   "# Contributing\n\nHow to contribute.", // Should be skipped
-		"not_markdown.txt":  "This is not markdown.",
+		"doc1.md":          "# Doc 1\n\nContent one.",
+		"doc2.md":          "# Doc 2\n\nContent two.",
+		"subdir/doc3.md":   "# Doc 3\n\nContent three.",
+		"README.md":        "# README\n\nThis is readme.",
+		"CHANGELOG.md":     "# Changelog\n\nChanges here.",         // Should be skipped
+		"CONTRIBUTING.md":  "# Contributing\n\nHow to contribute.", // Should be skipped
+		"not_markdown.txt": "This is not markdown.",
 	}
 
 	for name, content := range files {
@@ -380,9 +380,9 @@ func TestCollectDiagnostics_WithConfig(t *testing.T) {
 			Sentences: 10,
 		},
 		Readability: Readability{
-			FleschKincaidGrade: 5.0, // OK
-			ARI:                5.0, // OK
-			GunningFog:         8.0, // OK
+			FleschKincaidGrade: 5.0,  // OK
+			ARI:                5.0,  // OK
+			GunningFog:         8.0,  // OK
 			FleschReadingEase:  70.0, // OK
 		},
 		Admonitions: Admonitions{

--- a/pkg/analyzer/types.go
+++ b/pkg/analyzer/types.go
@@ -23,11 +23,11 @@ const (
 
 // Diagnostic represents a single issue found during analysis.
 type Diagnostic struct {
-	Line     int      `json:"line"`               // Line number (1-based), 0 if not applicable
-	Column   int      `json:"column,omitempty"`   // Column number (1-based), 0 if not applicable
-	Severity Severity `json:"severity"`           // error, warning, info
-	Rule     string   `json:"rule"`               // Rule ID (e.g., "readability/grade-level")
-	Message  string   `json:"message"`            // Human-readable message
+	Line     int      `json:"line"`             // Line number (1-based), 0 if not applicable
+	Column   int      `json:"column,omitempty"` // Column number (1-based), 0 if not applicable
+	Severity Severity `json:"severity"`         // error, warning, info
+	Rule     string   `json:"rule"`             // Rule ID (e.g., "readability/grade-level")
+	Message  string   `json:"message"`          // Human-readable message
 }
 
 // Admonitions contains admonition counts and details.

--- a/pkg/markdown/parser_test.go
+++ b/pkg/markdown/parser_test.go
@@ -58,23 +58,23 @@ func TestParse(t *testing.T) {
 			wantTotalLines: 6,
 		},
 		{
-			name: "fenced code block",
-			content: "# Title\n\n```go\nfunc main() {}\n```\n\nSome text.",
+			name:           "fenced code block",
+			content:        "# Title\n\n```go\nfunc main() {}\n```\n\nSome text.",
 			wantHeadings:   1,
 			wantCodeBlocks: 1,
 			wantTotalLines: 7,
 			wantCodeLines:  3,
 		},
 		{
-			name: "multiple code blocks",
-			content: "```\ncode1\n```\n\n```python\ncode2\n```",
+			name:           "multiple code blocks",
+			content:        "```\ncode1\n```\n\n```python\ncode2\n```",
 			wantCodeBlocks: 2,
 			wantTotalLines: 7,
 			wantCodeLines:  6,
 		},
 		{
-			name: "prose with empty lines",
-			content: "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
+			name:           "prose with empty lines",
+			content:        "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
 			wantProseLen:   10,
 			wantTotalLines: 5,
 			wantEmptyLines: 2,
@@ -129,10 +129,10 @@ More prose here.`,
 
 func TestParse_Headings(t *testing.T) {
 	tests := []struct {
-		name        string
-		content     string
-		wantLevels  []int
-		wantTexts   []string
+		name       string
+		content    string
+		wantLevels []int
+		wantTexts  []string
 	}{
 		{
 			name:       "all heading levels",
@@ -145,7 +145,7 @@ func TestParse_Headings(t *testing.T) {
 			content:    "# **Bold** heading",
 			wantLevels: []int{1},
 			// Parser strips markdown formatting, leaving just the suffix
-			wantTexts:  []string{" heading"},
+			wantTexts: []string{" heading"},
 		},
 		{
 			name:       "heading with inline code",
@@ -222,8 +222,8 @@ func TestParse_Admonitions(t *testing.T) {
 			wantTypes: []string{"note"},
 		},
 		{
-			name: "admonition inside code block ignored",
-			content: "```\n!!! note\n    This should not be counted.\n```",
+			name:      "admonition inside code block ignored",
+			content:   "```\n!!! note\n    This should not be counted.\n```",
 			wantCount: 0,
 		},
 		{
@@ -338,27 +338,27 @@ func TestParse_CodeBlocks(t *testing.T) {
 		wantContains []string
 	}{
 		{
-			name:       "fenced code block",
-			content:    "```\ncode here\n```",
-			wantBlocks: 1,
+			name:         "fenced code block",
+			content:      "```\ncode here\n```",
+			wantBlocks:   1,
 			wantContains: []string{"code here"},
 		},
 		{
-			name:       "fenced with language",
-			content:    "```go\npackage main\n```",
-			wantBlocks: 1,
+			name:         "fenced with language",
+			content:      "```go\npackage main\n```",
+			wantBlocks:   1,
 			wantContains: []string{"package main"},
 		},
 		{
-			name:       "indented code block",
-			content:    "    indented code\n    more code",
-			wantBlocks: 1,
+			name:         "indented code block",
+			content:      "    indented code\n    more code",
+			wantBlocks:   1,
 			wantContains: []string{"indented code"},
 		},
 		{
-			name: "multiple fenced blocks",
-			content: "```\nblock1\n```\n\n```\nblock2\n```",
-			wantBlocks: 2,
+			name:         "multiple fenced blocks",
+			content:      "```\nblock1\n```\n\n```\nblock2\n```",
+			wantBlocks:   2,
 			wantContains: []string{"block1", "block2"},
 		},
 	}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -298,9 +298,9 @@ func TestMarkdown_Output(t *testing.T) {
 func TestSummary_AllPass(t *testing.T) {
 	results := []*analyzer.Result{
 		{
-			File:   "doc1.md",
-			Status: "pass",
-			Structural: analyzer.Structural{Lines: 50, Words: 200},
+			File:        "doc1.md",
+			Status:      "pass",
+			Structural:  analyzer.Structural{Lines: 50, Words: 200},
 			Readability: analyzer.Readability{FleschReadingEase: 75.0},
 		},
 	}
@@ -317,8 +317,8 @@ func TestSummary_AllPass(t *testing.T) {
 func TestSummary_WithFailures(t *testing.T) {
 	results := []*analyzer.Result{
 		{
-			File:   "bad.md",
-			Status: "fail",
+			File:       "bad.md",
+			Status:     "fail",
 			Structural: analyzer.Structural{Lines: 50, Words: 200},
 			Readability: analyzer.Readability{
 				FleschKincaidGrade: 18.0,
@@ -343,9 +343,9 @@ func TestSummary_WithFailures(t *testing.T) {
 func TestReport_Output(t *testing.T) {
 	results := []*analyzer.Result{
 		{
-			File:   "doc.md",
-			Status: "pass",
-			Structural: analyzer.Structural{Lines: 50, Words: 200},
+			File:        "doc.md",
+			Status:      "pass",
+			Structural:  analyzer.Structural{Lines: 50, Words: 200},
 			Readability: analyzer.Readability{FleschReadingEase: 65.0},
 		},
 	}
@@ -368,8 +368,8 @@ func TestReport_Output(t *testing.T) {
 func TestReport_WithFailures(t *testing.T) {
 	results := []*analyzer.Result{
 		{
-			File:   "bad.md",
-			Status: "fail",
+			File:       "bad.md",
+			Status:     "fail",
 			Structural: analyzer.Structural{Lines: 500, Words: 200},
 			Readability: analyzer.Readability{
 				FleschKincaidGrade: 18.0,
@@ -494,13 +494,13 @@ func TestIdentifyIssue(t *testing.T) {
 
 func TestCalculateDistribution(t *testing.T) {
 	results := []*analyzer.Result{
-		{Readability: analyzer.Readability{FleschReadingEase: 95.0}},  // Very Easy
-		{Readability: analyzer.Readability{FleschReadingEase: 85.0}},  // Easy
-		{Readability: analyzer.Readability{FleschReadingEase: 75.0}},  // Fairly Easy
-		{Readability: analyzer.Readability{FleschReadingEase: 65.0}},  // Standard
-		{Readability: analyzer.Readability{FleschReadingEase: 55.0}},  // Fairly Difficult
-		{Readability: analyzer.Readability{FleschReadingEase: 40.0}},  // Difficult
-		{Readability: analyzer.Readability{FleschReadingEase: 20.0}},  // Very Difficult
+		{Readability: analyzer.Readability{FleschReadingEase: 95.0}}, // Very Easy
+		{Readability: analyzer.Readability{FleschReadingEase: 85.0}}, // Easy
+		{Readability: analyzer.Readability{FleschReadingEase: 75.0}}, // Fairly Easy
+		{Readability: analyzer.Readability{FleschReadingEase: 65.0}}, // Standard
+		{Readability: analyzer.Readability{FleschReadingEase: 55.0}}, // Fairly Difficult
+		{Readability: analyzer.Readability{FleschReadingEase: 40.0}}, // Difficult
+		{Readability: analyzer.Readability{FleschReadingEase: 20.0}}, // Very Difficult
 	}
 
 	dist := calculateDistribution(results)


### PR DESCRIPTION
## Summary
- Fixes gofmt issues flagged by Go Report Card
- Enhances pre-commit hooks to catch issues before they reach CI

## Changes

### Formatting Fixes
Applied `gofmt -s` to 4 files:
- `pkg/analyzer/analyzer_test.go`
- `pkg/analyzer/types.go`
- `pkg/markdown/parser_test.go`
- `pkg/output/output_test.go`

### Pre-commit Hooks (new order)
| Hook | Purpose | Go Report Card Check |
|------|---------|---------------------|
| `gofmt` | Format with `-s` simplification | gofmt ✅ |
| `go-vet` | Static analysis | go_vet ✅ |
| `golangci-lint` | Comprehensive linting | ineffassign ✅ |
| `gocyclo` | Complexity check (warning mode) | gocyclo ✅ |
| `go-test` | Run tests with race detector | - |
| `go-coverage` | 80% threshold (pre-push) | - |
| `readability` | Check docs readability | - |

### gocyclo Warning Mode
The gocyclo hook warns but doesn't block on existing violations:
- `main.run` (35) - needs refactoring
- `markdown.Parse` (21) - needs refactoring

Once refactored, change `|| echo "Warning..."` to make it strict.

## Test plan
- [x] `pre-commit run --all-files` passes
- [ ] CI passes
- [ ] Go Report Card shows improved scores after merge