### PR TITLE
fix: pass CODECOV_TOKEN to reusable CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
     permissions:
       contents: read
-      id-token: write
       security-events: write
 
   release-please:


### PR DESCRIPTION
## Summary

Fixes test analytics upload failures on main branch by adding `secrets: inherit` to the reusable workflow call in `release.yml`.

**Root cause:** When `release.yml` calls `ci.yml` as a reusable workflow, secrets are not automatically passed. The `CODECOV_TOKEN` secret was unavailable, causing test results uploads to fail with "Token required because branch is protected".

## Changes

- Add `secrets: inherit` to pass all secrets to ci.yml
- Remove `id-token: write` permission (no longer needed since we use token auth)

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, test analytics should appear in Codecov