### PR TITLE
fix: use regex patterns for Codecov component paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -39,27 +39,27 @@ component_management:
     - component_id: cli
       name: CLI
       paths:
-        - cmd/**
+        - "cmd/readability/.*"
 
     - component_id: analyzer
       name: Analyzer
       paths:
-        - pkg/analyzer/**
+        - "pkg/analyzer/.*"
 
     - component_id: config
       name: Configuration
       paths:
-        - pkg/config/**
+        - "pkg/config/.*"
 
     - component_id: markdown
       name: Markdown Parser
       paths:
-        - pkg/markdown/**
+        - "pkg/markdown/.*"
 
     - component_id: output
       name: Output Formatters
       paths:
-        - pkg/output/**
+        - "pkg/output/.*"
 
 # Flags for different test types
 flags:


### PR DESCRIPTION
## Summary

- Updates Codecov component path patterns from glob to regex syntax
- Codecov components support regex patterns (quoted strings) which are matched against file paths in coverage reports
- The previous glob patterns (`cmd/**`) weren't matching against the actual file paths in coverage output

## Changes

- `cmd/**` → `"cmd/readability/.*"`
- `pkg/analyzer/**` → `"pkg/analyzer/.*"`
- `pkg/config/**` → `"pkg/config/.*"`
- `pkg/markdown/**` → `"pkg/markdown/.*"`
- `pkg/output/**` → `"pkg/output/.*"`

## Test plan

- [ ] Verify CI passes
- [ ] After merge, check Codecov component views show coverage data instead of "No report uploaded"