### PR TITLE
ci: add TruffleHog secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog secret scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
## Summary

- Add TruffleHog secret scanner to CI security job
- Scans git history for leaked credentials
- Uses `--only-verified` to reduce false positives
- Required `fetch-depth: 0` for full git history access

## Test plan

- [x] CI workflow syntax valid
- [x] TruffleHog runs successfully in CI