### PR TITLE
fix: enable v prefix in release tags for Go module compliance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,12 +206,13 @@ jobs:
 
       - name: Update floating version tags
         run: |
-          MAJOR="${{ needs.release-please.outputs.major }}"
+          MAJOR="v${{ needs.release-please.outputs.major }}"
           TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Create v-prefixed major version alias (e.g., v1 -> v1.5.1)
           git tag -fa "${MAJOR}" "${TAG_NAME}" -m "Alias for ${TAG_NAME}"
           git push origin "${MAJOR}" --force
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "include-v-in-tag": false,
+  "include-v-in-tag": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Enable `v` prefix in release-please tags (`include-v-in-tag: true`)
- Update floating tag creation to use `v` prefix (`v1` instead of `1`)
- Pushed `v`-prefixed tags for all existing 1.x releases

## Why

Go modules **require** the `v` prefix on semantic version tags. Without it:
- `go install github.com/adaptive-enforcement-lab/readability/cmd/readability@v1.5.0` fails
- deps.dev does not show the versions
- pkg.go.dev does not index the versions

## Changes

**release-please-config.json**: `include-v-in-tag: false` → `true`

**release.yml**: Floating tag now uses `v` prefix (e.g., `v1` instead of `1`)

**Tags pushed**:
- v1.0.0, v1.1.0, v1.1.1, v1.2.0, v1.2.1, v1.2.2, v1.3.0, v1.3.1, v1.4.0, v1.5.0
- v1 (floating alias pointing to v1.5.0)

## Test plan

- [x] v-prefixed tags pushed to origin
- [x] v1 floating tag pushed
- [ ] deps.dev shows v1.x versions after indexing
- [ ] Future releases use v prefix