### PR TITLE
ci: add OpenSSF Scorecard security analysis

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Run weekly on Saturday at 01:30 UTC
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: scorecard


### PR DESCRIPTION
## Summary

Integrates [OpenSSF Scorecard](https://scorecard.dev/) to analyze security health metrics.

## What it does

- **Automated analysis**: Runs on push to main and weekly (Saturdays 01:30 UTC)
- **Public badge**: Results published to scorecard.dev with `publish_results: true`
- **GitHub Security**: SARIF uploaded to Security tab for code scanning alerts
- **Artifact retention**: Results stored for 5 days

## Checks performed

Scorecard evaluates ~18 security practices including:
- Branch protection, code review, CI tests
- Dependency updates (Dependabot), pinned dependencies
- Security policy, vulnerabilities, SAST, fuzzing
- License, maintained status, contributors

## After merge

- View results: https://scorecard.dev/viewer/?uri=github.com/adaptive-enforcement-lab/readability
- Add badge to README (optional):
```markdown
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/adaptive-enforcement-lab/readability/badge)](https://scorecard.dev/viewer/?uri=github.com/adaptive-enforcement-lab/readability)
```

## Test plan

- [ ] Workflow runs successfully on merge
- [ ] Results appear on scorecard.dev
- [ ] SARIF uploaded to GitHub Security tab