### PR TITLE
fix: move workflow permissions to job level for least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,15 @@ on:
         description: "Test coverage percentage"
         value: ${{ jobs.test.outputs.coverage }}
 
-permissions:
-  contents: read
-  security-events: write
+# Permissions set at job level for least privilege
+permissions: {}
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -32,6 +33,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       coverage: ${{ steps.coverage.outputs.total }}
     steps:
@@ -88,6 +91,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -101,6 +106,8 @@ jobs:
   test-action:
     name: Test Action
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -113,6 +120,8 @@ jobs:
   check-docs:
     name: Check Docs Readability
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -126,6 +135,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,8 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  pages: write
-  id-token: write
+# Permissions set at job level for least privilege
+permissions: {}
 
 jobs:
   # Run CI first - release only proceeds if CI passes
@@ -34,6 +31,9 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     needs: ci
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -62,6 +62,8 @@ jobs:
     name: Build Binaries
     runs-on: ubuntu-latest
     needs: release-please
+    permissions:
+      contents: read
     if: needs.release-please.outputs.release_created == 'true'
     strategy:
       matrix:
@@ -108,6 +110,8 @@ jobs:
     name: Upload Release Assets
     runs-on: ubuntu-latest
     needs: [release-please, build-binaries, ci]
+    permissions:
+      contents: write
     if: needs.release-please.outputs.release_created == 'true'
     steps:
       - name: Download binary artifacts
@@ -149,6 +153,10 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     needs: release-please
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     if: |
       always() && !cancelled() &&
       needs.release-please.result == 'success' &&
@@ -198,6 +206,8 @@ jobs:
     name: Update Tag Aliases
     runs-on: ubuntu-latest
     needs: [release-please, upload-assets]
+    permissions:
+      contents: write
     if: needs.release-please.outputs.release_created == 'true'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Addresses OpenSSF Scorecard **Token-Permissions** check (currently 0/10).

## Changes

Moves `permissions` from workflow level to job level in both `ci.yml` and `release.yml`.

### ci.yml
| Job | Permissions |
|-----|-------------|
| lint | contents: read |
| test | contents: read |
| build | contents: read |
| test-action | contents: read |
| check-docs | contents: read |
| security | contents: read, security-events: write |

### release.yml
| Job | Permissions |
|-----|-------------|
| ci (reusable) | contents: read, security-events: write |
| release-please | contents: write, pull-requests: write |
| build-binaries | contents: read |
| upload-assets | contents: write |
| build-docs | contents: write, pages: write, id-token: write |
| update-tags | contents: write |

## Why

Scorecard flags top-level `contents: write` and `security-events: write` as security risks. Moving to job-level permissions follows the principle of least privilege.

## Test plan

- [ ] CI passes on PR
- [ ] Release workflow still works (verify on next release)
- [ ] Scorecard Token-Permissions score improves