### PR TITLE
fix: use version tag for scorecard-action (cannot pin to SHA)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,8 +23,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # NOTE: scorecard-action cannot be pinned to SHA - it requires version tags
+      # for workflow verification. See: https://github.com/ossf/scorecard-action#workflow-restrictions
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "scorecard-action requires version tags for workflow verification",
+      "matchPackageNames": ["ossf/scorecard-action"],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
The ossf/scorecard-action has workflow verification requirements that prevent SHA pinning. The action validates that the workflow is using an official version tag, not a commit SHA.

## Changes
1. Revert scorecard-action from SHA (`ff5dd8929f96a8a4dc67d13f32b8c75057829621`) back to version tag (`v2.4.0`)
2. Add comment explaining the restriction
3. Add renovate packageRule to prevent future SHA pinning of this action

## Reference
https://github.com/ossf/scorecard-action#workflow-restrictions