### PR TITLE
fix: use version tags for all actions in scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,7 @@
+# NOTE: This workflow uses version tags instead of SHA pins because
+# scorecard-action has workflow verification that requires all actions
+# in this file to use version tags, not commit SHAs.
+# See: https://github.com/ossf/scorecard-action#workflow-restrictions
 name: Scorecard
 
 on:
@@ -19,12 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      # NOTE: scorecard-action cannot be pinned to SHA - it requires version tags
-      # for workflow verification. See: https://github.com/ossf/scorecard-action#workflow-restrictions
       - name: Run Scorecard analysis
         uses: ossf/scorecard-action@v2.4.0
         with:
@@ -33,14 +35,14 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        uses: actions/upload-artifact@v6
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@323fb8c0ad5be63b7a6ebf1f32c35882fcfea2cf # v3
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,8 @@
   ],
   "packageRules": [
     {
-      "description": "scorecard-action requires version tags for workflow verification",
-      "matchPackageNames": ["ossf/scorecard-action"],
+      "description": "scorecard.yml requires version tags for workflow verification (all actions)",
+      "matchFileNames": [".github/workflows/scorecard.yml"],
       "pinDigests": false
     }
   ]


### PR DESCRIPTION
## Summary
The ossf/scorecard-action has workflow verification that validates the ENTIRE workflow file, not just the scorecard action itself. All actions in scorecard.yml must use version tags, not commit SHAs.

## Changes
1. Revert ALL actions in scorecard.yml to version tags (checkout, upload-artifact, codeql-action)
2. Add explanatory comment at top of file
3. Update renovate to exclude entire scorecard.yml from SHA pinning using `matchFileNames`

## Reference
https://github.com/ossf/scorecard-action#workflow-restrictions

This is a follow-up to PR #111 which only fixed the scorecard-action itself but not the other actions in the workflow.