### PR TITLE
ci: add workflow_dispatch trigger to scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,6 +7,7 @@ name: Scorecard
 on:
   push:
     branches: [main]
+  workflow_dispatch:
   schedule:
     # Run weekly on Saturday at 01:30 UTC
     - cron: "30 1 * * 6"


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the Scorecard workflow to allow manual runs

## Test plan
- [ ] Verify workflow runs correctly when manually triggered