### PR TITLE
feat: add cosign signing for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,7 @@ jobs:
     needs: [release-please, build-binaries, ci]
     permissions:
       contents: write
+      id-token: write # Required for keyless signing with Sigstore
     if: needs.release-please.outputs.release_created == 'true'
     steps:
       - name: Download binary artifacts
@@ -127,18 +128,37 @@ jobs:
           name: sbom-cyclonedx
           path: dist/
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Sign binaries with Cosign
+        run: |
+          cd dist
+          for file in readability_*; do
+            cosign sign-blob --yes --output-signature "${file}.sig" "${file}"
+          done
+
       - name: Create archives
         run: |
           cd dist
           for file in readability_*; do
-            if [[ "$file" == *.exe ]]; then
+            if [[ "$file" == *.sig ]]; then
+              continue
+            elif [[ "$file" == *.exe ]]; then
               base="${file%.exe}"
-              zip "${base}.zip" "$file"
+              zip "${base}.zip" "$file" "${file}.sig"
             else
-              tar -czvf "${file}.tar.gz" "$file"
+              tar -czvf "${file}.tar.gz" "$file" "${file}.sig"
             fi
           done
           sha256sum *.tar.gz *.zip sbom.cdx.json > checksums.txt
+
+      - name: Sign archives with Cosign
+        run: |
+          cd dist
+          for file in *.tar.gz *.zip sbom.cdx.json checksums.txt; do
+            cosign sign-blob --yes --output-signature "${file}.sig" "${file}"
+          done
 
       - name: Upload to release
         env:
@@ -146,7 +166,7 @@ jobs:
         run: |
           cd dist
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
-            *.tar.gz *.zip sbom.cdx.json checksums.txt \
+            *.tar.gz *.zip *.sig sbom.cdx.json checksums.txt \
             --repo ${{ github.repository }}
 
   build-docs:


### PR DESCRIPTION
## Summary
- Adds [Sigstore Cosign](https://github.com/sigstore/cosign) signing to release artifacts
- Signs all `.tar.gz`, `.zip`, SBOM, and checksums files
- Uploads `.sig` signature files alongside release assets
- Uses keyless signing via Sigstore OIDC (GitHub Actions identity)

This enables the **Signed-Releases** check in [OpenSSF Scorecard](https://scorecard.dev).

## Changes
- Install `sigstore/cosign-installer@v4.0.0`
- Add `id-token: write` permission for OIDC-based keyless signing
- Sign artifacts with `cosign sign-blob --yes`
- Upload `.sig` files to GitHub releases

## Test plan
- [ ] CI passes
- [ ] On next release, verify `.sig` files are uploaded
- [ ] Verify signatures can be validated with `cosign verify-blob`