### PR TITLE
fix: update cosign signing for v3 API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,20 +135,20 @@ jobs:
         run: |
           cd dist
           for file in readability_*; do
-            cosign sign-blob --yes --output-signature "${file}.sig" "${file}"
+            cosign sign-blob --yes --bundle "${file}.bundle" "${file}"
           done
 
       - name: Create archives
         run: |
           cd dist
           for file in readability_*; do
-            if [[ "$file" == *.sig ]]; then
+            if [[ "$file" == *.bundle ]]; then
               continue
             elif [[ "$file" == *.exe ]]; then
               base="${file%.exe}"
-              zip "${base}.zip" "$file" "${file}.sig"
+              zip "${base}.zip" "$file" "${file}.bundle"
             else
-              tar -czvf "${file}.tar.gz" "$file" "${file}.sig"
+              tar -czvf "${file}.tar.gz" "$file" "${file}.bundle"
             fi
           done
           sha256sum *.tar.gz *.zip sbom.cdx.json > checksums.txt
@@ -157,7 +157,7 @@ jobs:
         run: |
           cd dist
           for file in *.tar.gz *.zip sbom.cdx.json checksums.txt; do
-            cosign sign-blob --yes --output-signature "${file}.sig" "${file}"
+            cosign sign-blob --yes --bundle "${file}.bundle" "${file}"
           done
 
       - name: Upload to release
@@ -166,7 +166,7 @@ jobs:
         run: |
           cd dist
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
-            *.tar.gz *.zip *.sig sbom.cdx.json checksums.txt \
+            *.tar.gz *.zip *.bundle sbom.cdx.json checksums.txt \
             --repo ${{ github.repository }}
 
   build-docs:


### PR DESCRIPTION
## Summary
Fixes the release signing failure caused by Cosign v3 API changes.

## Problem
Cosign v3 changed the keyless signing API. The `--output-signature` flag now requires `--bundle` or `--use-signing-config`.

Error: `must provide --bundle with --signing-config or --use-signing-config`

## Solution
- Update `cosign sign-blob` commands to use `--bundle` instead of `--output-signature`
- Bundle files (`.bundle`) contain signature, certificate, and transparency log entry
- Update archive creation to include `.bundle` files
- Update release upload to include `.bundle` files

## Test plan
- [ ] CI passes
- [ ] Re-run release workflow after merge to verify signing works