### PR TITLE
fix: move permissions to job level in sign-releases workflow

### DIFF
--- a/.github/workflows/sign-releases.yml
+++ b/.github/workflows/sign-releases.yml
@@ -12,14 +12,15 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   sign-releases:
     name: Sign Release Assets
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0


### PR DESCRIPTION
## Summary
- Move `permissions` from workflow level to job level for least privilege
- Satisfies Scorecard Token-Permissions check

## Changes
```yaml
# Before (workflow level)
permissions:
  contents: write
  id-token: write

# After (job level)
permissions: {}

jobs:
  sign-releases:
    permissions:
      contents: write
      id-token: write
```

## Test plan
- [x] CI passes
- [x] Token-Permissions alert should be resolved