### PR TITLE
chore: update slsa-github-generator to v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,8 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    # NOTE: Must use version tag (not SHA) for slsa-verifier compatibility
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.hash-binaries.outputs.hashes }}
       upload-assets: true


### PR DESCRIPTION
Update to latest stable version of slsa-github-generator.

Note: Must use version tag (not SHA) for slsa-verifier compatibility per [SLSA documentation](https://github.com/slsa-framework/slsa-github-generator#referencing-the-slsa-generator).