### PR TITLE
feat: add Go fuzz tests for OpenSSF Scorecard compliance

### DIFF
--- a/pkg/analyzer/fuzz_test.go
+++ b/pkg/analyzer/fuzz_test.go
@@ -1,0 +1,250 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzStripFrontmatter tests the stripFrontmatter function with arbitrary input.
+// This function removes YAML frontmatter delimited by --- markers.
+func FuzzStripFrontmatter(f *testing.F) {
+	// Seed corpus with various frontmatter patterns
+	seeds := []string{
+		// Valid frontmatter
+		"---\ntitle: Test\n---\nContent here.",
+		"---\nkey: value\n---\n\n# Heading",
+		"---\nmulti:\n  - item1\n  - item2\n---\nBody",
+
+		// No frontmatter
+		"Regular content without frontmatter.",
+		"# Heading\n\nParagraph.",
+		"",
+
+		// Edge cases
+		"---",           // Only opening marker
+		"---\n---",      // Empty frontmatter
+		"---\n---\n",    // Empty frontmatter with trailing newline
+		"---\nno close", // Unclosed frontmatter
+		"--- ",          // Marker with trailing space
+		" ---",          // Leading space (not valid frontmatter)
+		"---\n---\n---", // Multiple markers
+		"---\n---\n---\ncontent",
+		"----",          // Four dashes (not frontmatter)
+		"--",            // Two dashes (not frontmatter)
+		"---\ncontent\n---\nmore---content",
+
+		// Unicode and special characters
+		"---\ntitle: \U0001F600\n---\nContent",
+		"---\n\x00\x01\n---\nAfter",
+		"---\nkey: \"value with ---\"\n---\nBody",
+
+		// Large inputs
+		"---\n" + strings.Repeat("key: value\n", 100) + "---\nContent",
+		"---\n---\n" + strings.Repeat("x", 10000),
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, content string) {
+		result := stripFrontmatter(content)
+
+		// stripFrontmatter should never panic
+
+		// Invariant: result should never be longer than input
+		// (we're only removing content, never adding)
+		if len(result) > len(content) {
+			t.Errorf("stripFrontmatter result (%d bytes) longer than input (%d bytes)",
+				len(result), len(content))
+		}
+
+		// Invariant: if input doesn't start with ---, output equals input
+		if !strings.HasPrefix(content, "---") {
+			if result != content {
+				t.Error("stripFrontmatter modified content that doesn't start with ---")
+			}
+		}
+
+		// Invariant: result should not contain the frontmatter if it was valid
+		// (This is a weaker check - just verify no panic)
+	})
+}
+
+// FuzzCountSentences tests the countSentences function with arbitrary input.
+// This function counts sentences based on punctuation marks.
+func FuzzCountSentences(f *testing.F) {
+	// Seed corpus with various sentence patterns
+	seeds := []string{
+		// Normal sentences
+		"This is a sentence.",
+		"One. Two. Three.",
+		"Hello! How are you? Fine.",
+		"No punctuation here",
+
+		// Edge cases
+		"",
+		".",
+		"...",
+		"?!.",
+		"   ",
+		"\n\n\n",
+
+		// False positives for sentence detection
+		"Dr. Smith went to the store.",
+		"The price is $9.99 today.",
+		"Visit example.com for more.",
+		"Version 1.2.3 is released.",
+		"The U.S.A. is large.",
+		"3.14159 is pi.",
+
+		// Unicode
+		"\U0001F600 Emoji. More text.",
+		"Chinese\u3002 Japanese\u3002", // Ideographic full stop
+		"Arabic\u061F Question?",       // Arabic question mark
+
+		// Special characters
+		"\x00.\x01?\x02!",
+		"Tab\t.\tMore.",
+		"Newline.\nMore text.",
+
+		// Long inputs
+		strings.Repeat("Sentence. ", 100),
+		strings.Repeat("x", 10000) + ".",
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		count := countSentences(text)
+
+		// countSentences should never panic
+
+		// Invariant: count should always be >= 0
+		if count < 0 {
+			t.Errorf("countSentences returned %d, want >= 0", count)
+		}
+
+		// Invariant: for non-empty text, count should be >= 1
+		// (the function returns 1 if no punctuation found but text exists)
+		if len(text) > 0 && count < 1 {
+			t.Errorf("countSentences returned %d for non-empty input, want >= 1", count)
+		}
+
+		// Invariant: count should not exceed the number of sentence-ending chars + 1
+		maxPossible := strings.Count(text, ".") + strings.Count(text, "!") + strings.Count(text, "?")
+		if maxPossible == 0 && len(text) > 0 {
+			maxPossible = 1 // Function returns 1 for text without punctuation
+		}
+		if count > maxPossible {
+			t.Errorf("countSentences returned %d, but max possible is %d", count, maxPossible)
+		}
+	})
+}
+
+// FuzzCountWords tests the countWords function with arbitrary input.
+func FuzzCountWords(f *testing.F) {
+	// Seed corpus
+	seeds := []string{
+		"one two three",
+		"",
+		"   ",
+		"word",
+		"multiple   spaces   between",
+		"\ttabs\tand\nnewlines",
+		"hyphenated-word counts-as-one",
+		"\u00A0non-breaking space",
+		strings.Repeat("word ", 1000),
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		count := countWords(text)
+
+		// countWords should never panic
+
+		// Invariant: count should always be >= 0
+		if count < 0 {
+			t.Errorf("countWords returned %d, want >= 0", count)
+		}
+
+		// Invariant: empty or whitespace-only input should return 0
+		if strings.TrimSpace(text) == "" && count != 0 {
+			t.Errorf("countWords returned %d for whitespace-only input, want 0", count)
+		}
+	})
+}
+
+// FuzzCalculateReadingTime tests the calculateReadingTime function.
+func FuzzCalculateReadingTime(f *testing.F) {
+	// Seed with various word counts
+	f.Add(0)
+	f.Add(1)
+	f.Add(100)
+	f.Add(199)
+	f.Add(200)
+	f.Add(201)
+	f.Add(1000)
+	f.Add(-1)
+	f.Add(-100)
+	f.Add(1<<30 - 1) // Large positive
+	f.Add(-(1 << 30)) // Large negative
+
+	f.Fuzz(func(t *testing.T, words int) {
+		result := calculateReadingTime(words)
+
+		// calculateReadingTime should never panic
+
+		// Invariant: result should always be >= 0
+		if result < 0 {
+			t.Errorf("calculateReadingTime(%d) = %d, want >= 0", words, result)
+		}
+
+		// Invariant: for words <= 0, result should be 0
+		if words <= 0 && result != 0 {
+			t.Errorf("calculateReadingTime(%d) = %d, want 0", words, result)
+		}
+
+		// Invariant: for words > 0, result should be >= 1
+		if words > 0 && result < 1 {
+			t.Errorf("calculateReadingTime(%d) = %d, want >= 1", words, result)
+		}
+	})
+}
+
+// FuzzCalculateRatio tests the calculateRatio function.
+func FuzzCalculateRatio(f *testing.F) {
+	// Seed with various part/total combinations
+	f.Add(0, 0)
+	f.Add(0, 100)
+	f.Add(50, 100)
+	f.Add(100, 100)
+	f.Add(100, 50) // Part > total
+	f.Add(-1, 100)
+	f.Add(100, -1)
+	f.Add(-1, -1)
+	f.Add(1<<30, 1<<30)
+
+	f.Fuzz(func(t *testing.T, part, total int) {
+		result := calculateRatio(part, total)
+
+		// calculateRatio should never panic
+
+		// Invariant: for total == 0, result should be 0
+		if total == 0 && result != 0.0 {
+			t.Errorf("calculateRatio(%d, 0) = %f, want 0.0", part, result)
+		}
+
+		// Invariant: result should not be NaN or Inf (for valid inputs)
+		if total != 0 {
+			if result != result { // NaN check
+				t.Errorf("calculateRatio(%d, %d) returned NaN", part, total)
+			}
+		}
+	})
+}

--- a/pkg/markdown/fuzz_test.go
+++ b/pkg/markdown/fuzz_test.go
@@ -1,0 +1,169 @@
+package markdown
+
+import (
+	"testing"
+)
+
+// FuzzParse tests the Parse function with arbitrary markdown input.
+// This helps discover panics, hangs, or unexpected behavior with malformed input.
+func FuzzParse(f *testing.F) {
+	// Seed corpus with various markdown patterns
+	seeds := []string{
+		// Basic content
+		"# Heading\n\nSome text with `code`.",
+		"",
+		"   ",
+		"\n\n\n",
+
+		// Code blocks
+		"```go\nfunc main() {}\n```",
+		"```\ncode block\n```",
+		"```python\nprint('hello')\n```",
+		"    indented code block",
+
+		// Nested and complex structures
+		"# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6",
+		"# Title\n\n```\ncode\n```\n\n## Subtitle\n\nMore text.",
+
+		// Admonitions (MkDocs-style)
+		"!!! note\n    Content",
+		"!!! warning \"Title\"\n    Warning content.",
+		"!!! tip inline\n    Inline tip.",
+		"!!! note+\n    Collapsible.",
+		"!!!",
+		"!!! ",
+
+		// Edge cases
+		"```",            // Unclosed code block
+		"```\n```\n```",  // Multiple fence markers
+		"# ",             // Empty heading
+		"######",         // Heading without space
+		"#######",        // Invalid heading level
+		"**bold** _italic_ `code` [link](url)",
+		"!!! unknown_type \"Complex \\\"Escaped\\\" Title\"",
+
+		// Unicode and special characters
+		"\u0000",
+		"\xff\xfe",
+		"# \U0001F600 Emoji Heading",
+		"```\n\x00\x01\x02\n```",
+
+		// Large repetitive content
+		string(make([]byte, 1000)),
+		"#" + string(make([]byte, 100)),
+	}
+
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := Parse(data)
+
+		// We don't expect errors from Parse (it handles malformed input gracefully)
+		// but we verify invariants hold
+		if err != nil {
+			// If an error occurs, it should be a valid error, not a panic
+			return
+		}
+
+		// Invariant: result should never be nil when err is nil
+		if result == nil {
+			t.Error("Parse returned nil result without error")
+			return
+		}
+
+		// Invariant: TotalLines should always be >= 1 (even empty input has 1 line)
+		if result.TotalLines < 1 {
+			t.Errorf("TotalLines = %d, want >= 1", result.TotalLines)
+		}
+
+		// Invariant: CodeLines + EmptyLines <= TotalLines
+		if result.CodeLines+result.EmptyLines > result.TotalLines {
+			t.Errorf("CodeLines(%d) + EmptyLines(%d) > TotalLines(%d)",
+				result.CodeLines, result.EmptyLines, result.TotalLines)
+		}
+
+		// Invariant: slices should never be nil
+		if result.CodeBlocks == nil {
+			t.Error("CodeBlocks is nil, expected empty slice")
+		}
+		if result.Headings == nil {
+			t.Error("Headings is nil, expected empty slice")
+		}
+		if result.Admonitions == nil {
+			t.Error("Admonitions is nil, expected empty slice")
+		}
+
+		// Invariant: heading levels should be 1-6
+		for i, h := range result.Headings {
+			if h.Level < 1 || h.Level > 6 {
+				t.Errorf("Heading[%d].Level = %d, want 1-6", i, h.Level)
+			}
+			if h.Line < 1 {
+				t.Errorf("Heading[%d].Line = %d, want >= 1", i, h.Line)
+			}
+		}
+
+		// Invariant: admonition lines should be positive
+		for i, a := range result.Admonitions {
+			if a.Line < 1 {
+				t.Errorf("Admonition[%d].Line = %d, want >= 1", i, a.Line)
+			}
+		}
+	})
+}
+
+// FuzzParseAdmonition tests the parseAdmonition function directly.
+// This function parses MkDocs-style admonition syntax.
+func FuzzParseAdmonition(f *testing.F) {
+	// Seed corpus with various admonition patterns
+	seeds := []string{
+		// Valid patterns
+		"!!! note",
+		"!!! warning",
+		"!!! tip",
+		"!!! info",
+		"!!! danger",
+		"!!! example",
+		"!!! warning \"Custom Title\"",
+		"!!! tip inline",
+		"!!! note+",
+		"!!! example \"This Is A Long Title\"",
+
+		// Edge cases
+		"!!!",
+		"!!! ",
+		"!!!note",
+		"!!! note \"",
+		"!!! note \"Unclosed",
+		"!!! note \"\"",
+		"!!! \"no type\"",
+		"!!!  multiple  spaces",
+		"!!! type \"title\" extra",
+		"!!! type \"nested \"quotes\" here\"",
+
+		// Unicode and special characters
+		"!!! note \"\U0001F600\"",
+		"!!! \u0000",
+		"!!! type \"line\nbreak\"",
+
+		// Long inputs
+		"!!! " + string(make([]byte, 1000)),
+		"!!! type \"" + string(make([]byte, 1000)) + "\"",
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		result := parseAdmonition(line)
+
+		// parseAdmonition should never panic
+		// It can return nil for invalid input, which is expected
+
+		// Use result to satisfy the linter - the main purpose is panic detection
+		_ = result
+	})
+}


### PR DESCRIPTION
## Summary

- Add native Go fuzz tests to improve OpenSSF Scorecard Fuzzing check
- Target key parsing and utility functions with comprehensive seed corpora
- Use standard `func FuzzXxx(*testing.F)` pattern recognized by Scorecard

## Fuzz Tests Added

### markdown package (`pkg/markdown/fuzz_test.go`)
- **FuzzParse**: Tests `Parse()` with arbitrary markdown - validates invariants (line counts, heading levels 1-6, non-nil slices)
- **FuzzParseAdmonition**: Tests `parseAdmonition()` with malformed MkDocs admonition syntax

### analyzer package (`pkg/analyzer/fuzz_test.go`)
- **FuzzStripFrontmatter**: Tests YAML frontmatter removal with edge cases (unclosed blocks, multiple `---` markers)
- **FuzzCountSentences**: Tests sentence counting (handles URLs, decimals, abbreviations as false positives)
- **FuzzCountWords**: Tests word counting with unicode and various whitespace
- **FuzzCalculateReadingTime**: Tests reading time calculation with boundary values
- **FuzzCalculateRatio**: Tests ratio calculation including division by zero

## Test Results

All 7 fuzz tests pass with high execution counts:

| Test | Executions | Interesting Inputs |
|------|------------|-------------------|
| FuzzParse | 311k | 381 |
| FuzzParseAdmonition | 514k | 103 |
| FuzzStripFrontmatter | 402k | 61 |
| FuzzCountSentences | 538k | 31 |
| FuzzCountWords | 43k | 52 |
| FuzzCalculateReadingTime | 348k | 11 |
| FuzzCalculateRatio | 292k | 9 |

## OpenSSF Scorecard

Per the [Scorecard Fuzzing check documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing), native Go fuzzing is recognized under "Language-Specific Fuzzing Functions". This should improve the Fuzzing score from 0/10.

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Each fuzz test runs successfully for 5+ seconds without failures
- [x] CI passes