### PR TITLE
ci: add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
   workflow_call:
     outputs:
       coverage:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to CI workflow for manual runs

## Usage
After merge, trigger CI manually via:
```bash
gh workflow run ci.yml --ref <branch-name>
```

Or use the GitHub Actions UI "Run workflow" button.