### PR TITLE
fix: make release binaries executable after artifact download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
           pattern: readability_*
           merge-multiple: true
 
+      - name: Make binaries executable
+        run: chmod +x dist/readability_*
+
       - name: Generate hashes for SLSA provenance
         id: hash
         run: |


### PR DESCRIPTION
## Summary

Fixes non-executable release binaries by restoring permissions after artifact download in the `upload-assets` job.

## Problem

Users downloading release binaries from GitHub releases get non-executable files:

```bash
$ tar -xzf readability_darwin_arm64.tar.gz
$ ls -la readability_darwin_arm64
-rw-r--r--  1 mark  wheel  3531346 Dec 14 07:00 readability_darwin_arm64
$ ./readability_darwin_arm64 --version
zsh: permission denied: ./readability_darwin_arm64
```

This requires manual `chmod +x` after extraction, breaking the standard convention for release binaries.

## Root Cause

GitHub Actions artifacts don't preserve file permissions. The `upload-assets` job:
1. Downloads binary artifacts (loses +x permission)
2. Creates tar.gz archives with broken permissions
3. Uploads to GitHub releases

While tar preserves permissions in the archive, it archives the broken permissions from step 1.

## Solution

Add `chmod +x dist/readability_*` after downloading artifacts, before creating archives.

This matches:
- Industry standard convention (chmod 755 for release binaries)
- Fix already applied to `publish-container` job in #156
- Patterns used in GitHub Actions marketplace tools

## Verification

Tested locally with v1.10.4 release binaries - confirmed they lack executable permissions without this fix.

## References

- [tar preserves file permissions](http://kostas.krevatas.net/tar-command-preserve-file-permissions/)
- [GitHub Actions binary install patterns](https://github.com/marketplace/actions/install-a-binary-from-github-releases)
- Standard convention: chmod 755 for executable binaries