### PR TITLE
fix: Add v prefix to mkdocs version URLs for consistency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,7 @@ jobs:
           if [ "${{ needs.release-please.outputs.release_created }}" == "true" ]; then
             VERSION="${{ needs.release-please.outputs.version }}"
             MAJOR="${{ needs.release-please.outputs.major }}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
             echo "alias=v${MAJOR}" >> "$GITHUB_OUTPUT"
           else
             echo "version=dev" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Currently we have **inconsistent** version naming between git tags and documentation URLs:

| Location | Format | Example |
|----------|--------|---------|
| Git tags | `vX.Y.Z` | `v1.11.1` ✓ |
| Doc URLs | `X.Y.Z` | `/1.11.1/` ❌ |
| Aliases | `vX` | `/v1/` ✓ |

This is confusing for users who expect `/v1.11.1/` to match the git tag `v1.11.1`.

## Solution

Add the "v" prefix to mkdocs version URLs to match git tags:

| Location | Format | Example |
|----------|--------|---------|
| Git tags | `vX.Y.Z` | `v1.11.1` ✓ |
| Doc URLs | `vX.Y.Z` | `/v1.11.1/` ✓ |
| Aliases | `vX` | `/v1/` ✓ |

## Changes

Modified `.github/workflows/release.yml`:
```diff
- echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+ echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
```

This changes the mike deploy command from:
```bash
# Before
mike deploy --push --update-aliases 1.11.1 v1 latest

# After  
mike deploy --push --update-aliases v1.11.1 v1 latest
```

## Convention

This matches the convention used by major projects:
- ✅ **Kubernetes**: `/v1.28/`, `/v1.27/`
- ✅ **GitHub CLI**: `/v2.42/`, `/v2.41/`
- ❌ **Python**: `/3.12/` (but Python releases don't have "v" either)

## Impact

**Future releases** (v1.11.2+): Will deploy to `/vX.Y.Z/`  
**Existing versions** (v1.11.1 and earlier): Remain at `/X.Y.Z/`

Both URL formats will continue to work during the transition:
- `/1.11.1/` → existing version, still accessible
- `/v1.11.2/` → new version with v prefix
- `/v1/` → always points to latest v1.x (already has v prefix)
- `/latest/` → always points to latest release

## Testing

The next release will verify this works correctly. The version will deploy to both:
- `/vX.Y.Z/` (new versioned URL)
- `/vX/` (major version alias)
- `/latest/` (latest alias)

## Migration

If we want to migrate existing versions to the v-prefixed format, we can run:
```bash
# For each existing version
mike alias 1.11.1 v1.11.1
mike alias 1.11.0 v1.11.0
# etc.
```

But this is **not necessary** - both formats can coexist.

## Checklist

- [x] Workflow updated
- [x] No breaking changes (old URLs still work)
- [x] Matches industry convention (Kubernetes, GitHub CLI)
- [x] More user-friendly (matches git tag format)