### PR TITLE
docs: elevate Docker to first-class installation method

### DIFF
--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -1,9 +1,16 @@
 # Docker
 
-Run the readability CLI using Docker. The image is available from GitHub Container Registry.
+Run Readability using Docker. No installation needed. Works the same on every machine.
 
-!!! tip "Multi-Architecture Support"
-    The image works on both Intel/AMD (`linux/amd64`) and ARM (`linux/arm64`) systems. Docker picks the right one for you.
+**Why choose Docker:**
+
+- No local setup required
+- Works on any system
+- Pin to specific versions
+- Security verified with signed images
+- Supports Intel and ARM processors
+
+Pull the official image from GitHub Container Registry.
 
 ## Quick Start
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,16 +2,44 @@
 
 Get Readability running in under five minutes. Choose the method that fits your workflow.
 
-## Choose Your Path
+## Choose Your Installation Method
 
-| Method | Best For | Setup Time |
-|--------|----------|------------|
-| **GitHub Action** | Automated CI/CD checks | 2 minutes |
-| **Pre-commit Hook** | Local checks before commits | 3 minutes |
-| **CLI Tool** | Manual analysis, scripting | 2 minutes |
+Pick the method that works best for you.
+
+### 🐳 Docker
+
+Use Docker for CI/CD pipelines. Works in GitHub Actions, GitLab CI, and Jenkins.
+
+No setup needed. Just pull and run. Every environment gets the same results.
+
+[Docker Guide](docker.md)
+
+### 📦 Binary Download
+
+Download a single file. Run it on macOS, Linux, or Windows.
+
+Fast and simple. No dependencies. Works offline.
+
+[Installation Guide](installation.md#download-binary)
+
+### 🔧 Go Install
+
+Install from source using Go. Best for contributors and developers.
+
+Get the latest code. Easy to modify and rebuild.
+
+[Installation Guide](installation.md#go-install)
+
+### 🚀 GitHub Action
+
+Add one step to your workflow file. No installation needed.
+
+Checks run on every pull request. Blocks merges when quality drops.
+
+[GitHub Action Guide](../github-action/index.md)
 
 !!! tip "New to Readability?"
-    Start with the **GitHub Action**. It requires no local installation and catches issues automatically on every pull request.
+    Start with **Docker** for CI/CD workflows or **Binary Download** for local use. Both methods get you running in under 2 minutes.
 
 ## Quick Preview
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,6 +16,30 @@ No installation needed. Add this step to any workflow file in `.github/workflows
 !!! note "Version Pinning"
     Use `@v1` for the latest stable release. This automatically updates to new minor versions while staying on major version 1.
 
+## Docker
+
+Pull the official image from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/adaptive-enforcement-lab/readability:latest
+```
+
+Verify it works:
+
+```bash
+docker run --rm ghcr.io/adaptive-enforcement-lab/readability:latest --version
+```
+
+Analyze your documentation:
+
+```bash
+docker run --rm -v "$(pwd):/workspace" \
+  ghcr.io/adaptive-enforcement-lab/readability:latest /workspace/docs/
+```
+
+!!! tip "Advanced Docker Usage"
+    See the [Docker Guide](docker.md) for details on image tags, security verification, CI/CD examples, and volume mounting patterns.
+
 ## Pre-commit Hook
 
 Pre-commit hooks run checks before each commit. This catches issues early, on your local machine.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,9 +6,18 @@ Run your first readability analysis and understand the results.
 
 Point the tool at your documentation folder:
 
-```bash
-readability docs/
-```
+=== "Docker"
+
+    ```bash
+    docker run --rm -v "$(pwd):/workspace" \
+      ghcr.io/adaptive-enforcement-lab/readability:latest /workspace/docs/
+    ```
+
+=== "Local Binary"
+
+    ```bash
+    readability docs/
+    ```
 
 You'll see a table like this:
 
@@ -42,9 +51,19 @@ Choose the format that fits your needs:
 
 Add `--check` to fail when thresholds are exceeded. This is useful for CI pipelines.
 
-```bash
-readability --check docs/
-```
+=== "Docker"
+
+    ```bash
+    docker run --rm -v "$(pwd):/workspace" \
+      ghcr.io/adaptive-enforcement-lab/readability:latest \
+      --check /workspace/docs/
+    ```
+
+=== "Local Binary"
+
+    ```bash
+    readability --check docs/
+    ```
 
 The command exits with code 1 if any file fails. Use this in your CI to block PRs with readability issues.
 
@@ -52,9 +71,19 @@ The command exits with code 1 if any file fails. Use this in your CI to block PR
 
 Override defaults from the command line:
 
-```bash
-readability --check --max-grade 12 --max-ari 12 docs/
-```
+=== "Docker"
+
+    ```bash
+    docker run --rm -v "$(pwd):/workspace" \
+      ghcr.io/adaptive-enforcement-lab/readability:latest \
+      --check --max-grade 12 --max-ari 12 /workspace/docs/
+    ```
+
+=== "Local Binary"
+
+    ```bash
+    readability --check --max-grade 12 --max-ari 12 docs/
+    ```
 
 Or create a `.readability.yml` file for persistent settings:
 
@@ -68,6 +97,8 @@ thresholds:
 
 !!! tip "Config File Location"
     Place `.readability.yml` in your repository root. The tool finds it automatically.
+
+    When using Docker, the config file is automatically detected when you mount your workspace with `-v "$(pwd):/workspace"`.
 
 ## What's Next?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,8 +109,8 @@ nav:
   - Getting Started:
       - getting-started/index.md
       - Installation: getting-started/installation.md
-      - Quick Start: getting-started/quick-start.md
       - Docker: getting-started/docker.md
+      - Quick Start: getting-started/quick-start.md
   - GitHub Action:
       - github-action/index.md
       - Configuration: github-action/configuration.md


### PR DESCRIPTION
## Summary

Restructures getting started documentation to present Docker as an equal installation method alongside binary downloads, Go install, and GitHub Actions.

## Changes

- **index.md**: Add installation method decision guide with Docker as first option
- **installation.md**: Add Docker section before pre-commit hook
- **quick-start.md**: Convert all examples to tabbed content (Docker + Local Binary)
- **docker.md**: Enhance introduction with clear benefits
- **mkdocs.yml**: Reorder navigation to position Docker before Quick Start

## Impact

Docker is now presented as a first-class citizen rather than an alternative or secondary option. Users can choose the installation method that best fits their workflow without bias.

## Testing

- [x] All documentation passes readability checks
- [x] Tabbed content renders correctly with Material theme
- [x] Navigation order reflects equal status
- [x] Pre-commit hooks pass

Fixes #170