### PR TITLE
ci: replace deprecated codecov test-results-action with codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml
           flags: unit
+          report_type: test_results
           fail_ci_if_error: false
 
       - name: Check coverage threshold


### PR DESCRIPTION
## Summary

Replaces the deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v5` using the `report_type: test_results` parameter.

## Problem

The CI workflow was showing a deprecation warning:

> This action is being deprecated in favor of 'codecov-action'. Please update CI accordingly to use 'codecov-action@v5' with 'report_type: test_results'. The 'codecov-action' should and can be run at least once for coverage and once for test results

## Solution

- Replace `codecov/test-results-action@v1` with `codecov/codecov-action@v5`
- Add `report_type: test_results` parameter to the test results upload step
- Keep existing configuration (flags, error handling, conditional execution)

## Changes

**Before:**
```yaml
- name: Upload test results to Codecov
  if: ${{ !cancelled() }}
  uses: codecov/test-results-action@v1
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    files: ./junit.xml
    flags: unit
    fail_ci_if_error: false
```

**After:**
```yaml
- name: Upload test results to Codecov
  if: ${{ !cancelled() }}
  uses: codecov/codecov-action@v5
  with:
    token: ${{ secrets.CODECOV_TOKEN }}
    files: ./junit.xml
    flags: unit
    report_type: test_results
    fail_ci_if_error: false
```

## Testing

- [x] Pre-commit hooks pass
- [ ] CI workflow runs without deprecation warning
- [ ] Coverage upload continues to work
- [ ] Test results upload continues to work

## Impact

- Removes deprecation warning from CI workflow
- Maintains all existing functionality
- Uses recommended codecov integration approach
- No changes to test execution or reporting behavior