### PR TITLE
fix: update schema URL to work with mike versioning

### DIFF
--- a/docs/developer-manual/issue-160/01-schema-creation.md
+++ b/docs/developer-manual/issue-160/01-schema-creation.md
@@ -36,7 +36,7 @@ Based on the Go structs in `pkg/config/config.go:12-33`, the schema will define:
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://readability.adaptive-enforcement-lab.com/schemas/config.json",
+  "$id": "https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json",
   "title": "Readability Configuration",
   "description": "Configuration schema for readability markdown analyzer",
   "type": "object",

--- a/docs/developer-manual/issue-160/02-schema-publishing.md
+++ b/docs/developer-manual/issue-160/02-schema-publishing.md
@@ -29,7 +29,7 @@ Publish the JSON Schema to your existing MkDocs Material documentation site, lev
 - **Deployment**: GitHub Pages with custom domain
 - **HTTPS**: Enabled by default
 
-**Schema URL**: `https://readability.adaptive-enforcement-lab.com/schemas/config.json`
+**Schema URL**: `https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json`
 
 ## Implementation Steps
 
@@ -61,7 +61,7 @@ cp schemas/readability-config.schema.json docs/schemas/config.json
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://readability.adaptive-enforcement-lab.com/schemas/config.json",
+  "$id": "https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json",
   "title": "Readability Configuration",
   "description": "Configuration schema for readability markdown analyzer",
   // ... rest of schema
@@ -143,7 +143,7 @@ After deployment, verify schema is accessible:
 
 ```bash
 # Check schema is accessible
-curl -I https://readability.adaptive-enforcement-lab.com/schemas/config.json
+curl -I https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 # Expected response:
 # HTTP/2 200
@@ -155,7 +155,7 @@ Test schema in IDE:
 
 ```yaml
 # .readability.yml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12
@@ -195,7 +195,7 @@ readability/
 Use single, stable URL that always points to latest schema:
 
 ```
-https://readability.adaptive-enforcement-lab.com/schemas/config.json
+https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 ```
 
 **Rationale**:
@@ -249,15 +249,15 @@ readability --config .readability.yml --validate-config
 
 ```bash
 # 1. Verify schema is accessible
-curl -I https://readability.adaptive-enforcement-lab.com/schemas/config.json
+curl -I https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 # 2. Verify correct Content-Type
 curl -s -o /dev/null -w "%{content_type}\n" \
-  https://readability.adaptive-enforcement-lab.com/schemas/config.json
+  https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 # Should output: application/json
 
 # 3. Verify schema is valid JSON
-curl -s https://readability.adaptive-enforcement-lab.com/schemas/config.json | jq .
+curl -s https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json | jq .
 ```
 
 ### IDE Integration Tests
@@ -266,7 +266,7 @@ curl -s https://readability.adaptive-enforcement-lab.com/schemas/config.json | j
 
 1. Create test `.readability.yml`:
    ```yaml
-   # yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+   # yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
    thresholds:
      max_grade:

--- a/docs/developer-manual/issue-160/03-yaml-integration.md
+++ b/docs/developer-manual/issue-160/03-yaml-integration.md
@@ -24,7 +24,7 @@ This comment instructs the YAML language server to validate the file against the
 #### Format 1: YAML Language Server Directive (Recommended)
 
 ```yaml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12
@@ -235,13 +235,13 @@ thresholds:
 
 **For Documentation/Examples**: Use canonical domain URL (available immediately)
 ```yaml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 ```
 
 **For Repository's Own Config**: Use hosted URL from day one
 ```yaml
 # Production (immediate)
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 # Alternative: After SchemaStore approval (automatic discovery, explicit reference optional)
 # yaml-language-server: $schema=https://json.schemastore.org/readability.json
@@ -348,7 +348,7 @@ thresholds:
 
 ```bash
 # Edit .readability.yml
-sed -i '1i# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json\n' .readability.yml
+sed -i '1i# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json\n' .readability.yml
 ```
 
 Verify in VS Code that autocomplete works.
@@ -388,7 +388,7 @@ Add to README.md:
 Create `.readability.yml` in your repository root:
 
 ```yaml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12      # High school senior reading level

--- a/docs/developer-manual/issue-160/06-documentation.md
+++ b/docs/developer-manual/issue-160/06-documentation.md
@@ -32,7 +32,7 @@ Comprehensive documentation updates to guide users through JSON Schema features,
 Create `.readability.yml` in your repository root:
 
 ```yaml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12      # Maximum Flesch-Kincaid grade level
@@ -80,7 +80,7 @@ Open `.readability.yml` and start typing to see autocomplete suggestions.
 To explicitly specify the schema (for version pinning or custom URLs):
 
 ```yaml
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12
@@ -204,7 +204,7 @@ See https://github.com/markcheret/readability/blob/main/docs/cli/config-file.md 
   - Runtime validation with detailed error messages and suggestions
   - `--validate-config` flag to test configuration without running analysis
   - Schema available at:
-    - https://readability.adaptive-enforcement-lab.com/schemas/config.json (canonical)
+    - https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json (canonical)
     - https://json.schemastore.org/readability.json (after SchemaStore approval)
 
 ### Changed

--- a/docs/developer-manual/issue-160/07-schemastore-submission.md
+++ b/docs/developer-manual/issue-160/07-schemastore-submission.md
@@ -52,7 +52,7 @@ thresholds:
 **Without SchemaStore** (manual):
 ```yaml
 # User must add schema reference manually
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12  # Autocomplete only works with explicit reference
@@ -124,7 +124,7 @@ cp /path/to/readability/docs/schemas/config.json \
 **Schema Requirements**:
 - Must be valid JSON (not YAML)
 - Must validate against JSON Schema meta-schema
-- `$id` should reference your canonical URL: `https://readability.adaptive-enforcement-lab.com/schemas/config.json`
+- `$id` should reference your canonical URL: `https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json`
 - SchemaStore will serve a **copy** at `https://json.schemastore.org/readability.json`
 
 **Important**: Your domain remains the authoritative source. SchemaStore is a mirror for discovery.
@@ -174,7 +174,7 @@ Adds JSON Schema for [readability](https://github.com/adaptive-enforcement-lab/r
 - **Project**: https://github.com/adaptive-enforcement-lab/readability
 - **Documentation**: https://readability.adaptive-enforcement-lab.com
 - **Schema Spec**: Draft 2020-12
-- **Canonical URL**: https://readability.adaptive-enforcement-lab.com/schemas/config.json
+- **Canonical URL**: https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 ## Schema Features
 - Comprehensive field descriptions
@@ -301,7 +301,7 @@ If SchemaStore submission is rejected or delayed:
 **Fallback**:
 ```yaml
 # Users add this line (one-time setup)
-# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/schemas/config.json
+# yaml-language-server: $schema=https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
 
 thresholds:
   max_grade: 12

--- a/docs/developer-manual/issue-160/index.md
+++ b/docs/developer-manual/issue-160/index.md
@@ -41,7 +41,7 @@ This implementation is divided into eight major components:
 
 **Component 2: Schema Publishing** - ✅ COMPLETE (Current PR)
 - Schema published to `docs/schemas/config.json`
-- Accessible at `https://readability.adaptive-enforcement-lab.com/schemas/config.json`
+- Accessible at `https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json`
 - Zero new infrastructure (reuses existing MkDocs deployment)
 - Tested locally with `mkdocs serve` - schema accessible and valid JSON
 

--- a/docs/schemas/config.json
+++ b/docs/schemas/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://readability.adaptive-enforcement-lab.com/schemas/config.json",
+  "$id": "https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json",
   "title": "Readability Configuration",
   "description": "Configuration schema for readability markdown analyzer",
   "type": "object",


### PR DESCRIPTION
## Problem

The schema was published at `docs/schemas/config.json` in PR #182, but the $id URL was:
```
https://readability.adaptive-enforcement-lab.com/schemas/config.json
```

This returns **404** because mike versioning serves all files under version paths like:
- `/v1.12.0/schemas/config.json`
- `/v1/schemas/config.json`  
- `/latest/schemas/config.json`

The root path `/schemas/config.json` doesn't exist.

## Solution

Update schema $id to use the `/latest/` version alias:
```
https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
```

The `/latest/` alias always points to the newest deployed version, providing a stable URL that works with mike's versioning structure.

## Changes

### Schema File
- `docs/schemas/config.json`: Updated `$id` field to include `/latest/` in URL path

### Documentation Updates
Updated all references in implementation plan documentation:
- `docs/developer-manual/issue-160/01-schema-creation.md`
- `docs/developer-manual/issue-160/02-schema-publishing.md`
- `docs/developer-manual/issue-160/03-yaml-integration.md`
- `docs/developer-manual/issue-160/06-documentation.md`
- `docs/developer-manual/issue-160/07-schemastore-submission.md`
- `docs/developer-manual/issue-160/index.md`

## Verification

**Current Status** (before this PR):
```bash
curl -I https://readability.adaptive-enforcement-lab.com/schemas/config.json
# HTTP/2 404

curl -I https://readability.adaptive-enforcement-lab.com/latest/schemas/config.json
# HTTP/2 200
```

**After Merge**:
The schema at `/latest/schemas/config.json` will have the correct `$id` that matches its deployment URL.

## Alternative Considered

Could have set up a redirect from `/schemas/` to `/latest/schemas/`, but using `/latest/` directly in the $id is simpler and more explicit about the versioning structure.

## Impact

- ✅ Schema URL will now work for IDE autocomplete
- ✅ No breaking changes (old URL never worked)
- ✅ `/v1/` and `/v1.12.0/` URLs continue to work for pinned versions
- ✅ `.readability.yml` uses local path `./docs/schemas/config.json` (unaffected)

## Related

- Fixes URL issue from PR #182
- Ref: #160 (Component 2: Schema Publishing)