### PR TITLE
feat: upgrade container image to SLSA Build L3 provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,24 @@ jobs:
       upload-assets: true
       upload-tag-name: ${{ needs.release-please.outputs.tag_name }}
 
+  # Generate SLSA Level 3 provenance attestation for the container image
+  # NOTE: Must use version tag (not SHA) for slsa-verifier compatibility
+  container-provenance:
+    name: Container SLSA Provenance
+    needs: [release-please, publish-container]
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.publish-container.outputs.image }}
+      digest: ${{ needs.publish-container.outputs.digest }}
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
@@ -387,7 +405,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
+          provenance: false
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1


### PR DESCRIPTION
## Summary

- Replaces BuildKit's inline SLSA L2 provenance (`provenance: true` on `docker/build-push-action`) with a dedicated `container-provenance` job that delegates to `slsa-framework/slsa-github-generator`
- Sets `provenance: false` on the `build-push-action` step to remove the weaker L2 attestation from the image index
- The new job calls `generator_container_slsa3.yml@v2.1.0`, the same generator version already used by the binary `provenance` job — achieving parity across all release artifacts

## Why

The previous setup had BuildKit generate provenance inline within the `publish-container` job. That provenance named the repo's own Actions run as the builder ID, which cannot satisfy SLSA Build L3's isolated-trusted-builder requirement (the owner of the repo controls the job that generates the attestation).

The `slsa-framework/slsa-github-generator` reusable workflow runs in an isolated context outside the calling repo's control. It signs the provenance via Sigstore/Rekor keyless signing and attaches it to the image digest, making the builder ID the generator workflow itself. This is the same trust model the binary releases already use.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | `provenance: true` → `provenance: false` on `docker/build-push-action` |
| `.github/workflows/release.yml` | New `container-provenance` job added after `publish-container` |

## Verification

After merge, on the next release, verify the builder ID is the SLSA generator (not this repo):

```bash
cosign verify-attestation \
  --type slsaprovenance \
  --certificate-identity-regexp 'https://github.com/slsa-framework/slsa-github-generator/.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  ghcr.io/adaptive-enforcement-lab/readability:latest \
  | jq '.payload | @base64d | fromjson | .predicate.runDetails.builder.id'
```

Expected: `https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0`

## Test plan

- [ ] No Go code changed — existing `go test -race ./...` and `golangci-lint` pass unchanged
- [ ] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Spec-compliance review passed (all required fields present, no extras)
- [ ] Code-quality review passed (permissions minimal, outputs valid, `if` condition consistent with other release-gated jobs, `@v2.1.0` tag correct for `slsa-verifier` compatibility)
- [ ] Verify SLSA L3 attestation on next release using `cosign verify-attestation` command above