### PR TITLE
fix(ci): authenticate release-please with the CORE App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,21 @@ jobs:
         with:
           egress-policy: audit
 
+      # GITHUB_TOKEN-authored PRs do not start workflow runs; their checks sit
+      # in action_required until a maintainer approves them by hand. An App
+      # token attributes the PR to the App instead, so CI starts on its own.
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.CORE_APP_ID }}
+          private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
+          owner: adaptive-enforcement-lab
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## The symptom

Release PRs sit with their CI checks in `action_required` until someone clicks **Approve and run**.

## Root cause

`release.yml` ran release-please with `secrets.GITHUB_TOKEN`, so its PRs were authored by `github-actions[bot]`. GitHub gates workflow runs on PRs from that identity.

The gate keys on **who authored the PR**, not on which event fires or whether the branch is a fork — PR #294 is `isCrossRepository: false` and still got gated.

## Verified, not assumed

A controlled comparison inside this org. Same trigger (`pull_request`), same approval policy (`first_time_contributors`), same org. Only the token differs:

| Repo | release-please token | PR author | `run_attempt` | `triggering_actor` |
| --- | --- | --- | --- | --- |
| `readability` | `secrets.GITHUB_TOKEN` | `github-actions[bot]` | **2** | **`markcheret`** — approved by hand |
| `claude-skills` ×4 | App token | `ael-core[bot]` | **1** | `ael-core[bot]` — no human |

`attempt=1` with a bot as triggering actor means those runs were never stopped.

## The change

12 lines. Generate a CORE App token and hand it to release-please:

```yaml
- name: Generate App Token
  id: app-token
  uses: actions/create-github-app-token@bcd2ba49... # v3
  with:
    app-id: ${{ secrets.CORE_APP_ID }}
    private-key: ${{ secrets.CORE_APP_PRIVATE_KEY }}
    owner: adaptive-enforcement-lab

- uses: googleapis/release-please-action@45996ed1... # v5
  with:
    token: ${{ steps.app-token.outputs.token }}
```

`CORE_APP_ID` / `CORE_APP_PRIVATE_KEY` are org secrets with **ALL** repository visibility, and `ael-core` is installed org-wide, so no per-repo setup is needed. This matches the pattern already running in `adaptive-enforcement-lab-com` and `claude-skills`.

## Why not `pull_request_target`

It would also bypass the gate, and it is the wrong instrument here.

`ci.yml` checks out and executes PR code across seven jobs. Under `pull_request_target`:

| Approach | Outcome |
| --- | --- |
| Default checkout | Tests the **base** ref — CI passes vacuously on every PR |
| Checkout `head.ref` | Untrusted code runs with base-repo context and `CODECOV_TOKEN` in scope |

Our own guidance states it plainly — `docs/secure/scorecard/checks/supply-chain/part-2.md:228`: *"`pull_request_target` workflows never checkout PR code."* OpenSSF Scorecard's Dangerous-Workflow check would flag it.

This repo currently has top-level `permissions: {}`, per-job `contents: read`, SHA-pinned actions and harden-runner. Fixing the PR author removes the gate without touching any of that. `ci.yml` is unchanged by this PR.

## Audit

`repos audit release-process`, before and after:

```
BEFORE: 3/5  42.2%
AFTER:  4/5  53.1%

RESOLVED: RW-009, RW-010, RW-018
NEW:      none

has_app_token                  = True
app_token_in_release_please    = True
app_token_uses_correct_secrets = True
```

## Scope

PR #294 is left untouched. It was already authored by `github-actions[bot]`, so it stays gated regardless — this fix applies to release PRs created from here on.

## Checklist

- [x] Clear, descriptive commit message
- [x] YAML validated
- [x] Pre-commit hooks pass
- [x] Action pinned to SHA with correct version comment
- [x] No change to `ci.yml` or its permissions model